### PR TITLE
Fixed edge case while marking pages as active

### DIFF
--- a/_includes/nav-items.html
+++ b/_includes/nav-items.html
@@ -1,6 +1,7 @@
 <ul class="kbc-nav-sidebar nav nav-sidebar">
 {% for item in include.items %}
-    <li{% if item.url == page.url or page.url contains item.url %} class="active"{% endif %}>
+    {% assign pageUrlSplitByItemUrl = page.url | split: item.url  %}
+    <li{% if item.url == page.url or page.url contains item.url and pageUrlSplitByItemUrl.first.size == 0 %} class="active"{% endif %}>
         <a href="{{ item.url }}">{{ item.title }}</a>
         {% if item.items %}
         {% include nav-items.html items=item.items %}


### PR DESCRIPTION
Pages with similar slug parts was incorrectly marked as active.
Example:
- `/extend/docker/tutorial/` (current page)
- `/tutorial/` (falsely marked as active)