### PR TITLE
Fix subdomain and path names

### DIFF
--- a/extend/component/tutorial/index.md
+++ b/extend/component/tutorial/index.md
@@ -17,7 +17,7 @@ You need to have a computer with working [Docker](https://www.docker.com/what-do
 To be able to create new components, you also need to have an account in the [Keboola Developer Portal](https://components.keboola.com/),
 which manages the list of components available in KBC.
 
-The Developer portal uses different credentials than KBC. [Creating an account](https://apps.keboola.com/auth/create-account) is free; it requires a working email address
+The Developer portal uses different credentials than KBC. [Creating an account](https://components.keboola.com/auth/create-account) is free; it requires a working email address
 (to which a confirmation email will be sent) and a mobile phone for a mandatory two-factor authorization.
 
 When you log in to the developer portal, you have to join a **vendor** --- an organization of

--- a/extend/publish/index.md
+++ b/extend/publish/index.md
@@ -32,7 +32,7 @@ visiting a link with the specific component ID:
     https://connection.keboola.com/admin/projects/{PROJECT_ID}/extractors/{COMPONENT_ID}
 
 This way you can fully test your component before requesting its publication. Unpublished
-components are also not part of the [Public Component list](https://apps.keboola.com/apps).
+components are also not part of the [Public Component list](https://components.keboola.com/components).
 An existing configuration of a non-public component is accessible the same way as a configuration of any other component.
 
 **Important**: Changes made in the Developer Portal take up to 5 minutes to propagate to all Keboola Connection instances in all regions.


### PR DESCRIPTION
Rename apps.keboola.com to components.keboola.com