### PR TITLE
Deploy "v" prefixed tags

### DIFF
--- a/extend/component/deployment/index.md
+++ b/extend/component/deployment/index.md
@@ -102,7 +102,7 @@ docker push ${REPOSITORY}:${TRAVIS_TAG}
 docker push ${REPOSITORY}:latest
 
 # Update the tag in Keboola Developer Portal -> Deploy to KBC
-if echo ${TRAVIS_TAG} | grep -c '^[0-9]\+\.[0-9]\+\.[0-9]\+$'
+if echo ${TRAVIS_TAG} | grep -c '^v\?[0-9]\+\.[0-9]\+\.[0-9]\+$'
 then
     docker run --rm \
         -e KBC_DEVELOPERPORTAL_USERNAME \


### PR DESCRIPTION
Consider auto deployment of tags with "v" prefix, e.g. `v1.0.1`

(PR here, because "what is not in the documentation does not exist")