### PR TITLE
Add "api.caCertificate" parameter to generic extractor config

### DIFF
--- a/_includes/config-events.js
+++ b/_includes/config-events.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', function() {
     // Api
     $("span:contains('\"baseUrl\"')").wrap("<a href='/extend/generic-extractor/configuration/api/#base-url'></a>");
+    $("span:contains('\"caCertificate\"')").wrap("<a href='/extend/generic-extractor/configuration/api/#ca-certificate'></a>");
     $("span:contains('\"retryConfig\"')").wrap("<a href='/extend/generic-extractor/configuration/api/#retry-configuration'></a>");
     $("span:contains('\"http\"')").first().wrap("<a href='/extend/generic-extractor/configuration/api/#default-http-options'></a>");
     $("span:contains('\"headers\"')").first().wrap("<a href='/extend/generic-extractor/configuration/api/#headers'></a>");

--- a/_includes/config-map.json
+++ b/_includes/config-map.json
@@ -2,6 +2,7 @@
     "parameters": {
         "api": {
             "baseUrl": "https://example.com/v3.0/",
+            "caCertificate": "-----BEGIN CERTIFICATE-----\nMIIFaz....",
             "pagination": {
                 "method": "multiple",
                 "scrollers": {

--- a/extend/generic-extractor/configuration/api/index.md
+++ b/extend/generic-extractor/configuration/api/index.md
@@ -55,10 +55,12 @@ See the [`endpoint` configuration](/extend/generic-extractor/configuration/confi
 how `api.baseUrl` and `jobs.endpoint` work together.
 
 ## CA certificate
-The `caCertificate` configuration **defines custom certificate authority bundle in `crt`/`pem` format**.
-It makes possible connection to a server with a untrusted/self-signed certificate.
+The `caCertificate` configuration **defines custom certificate authority bundle in 
+[`crt`/`pem` format](https://serverfault.com/questions/9708/what-is-a-pem-file-and-how-does-it-differ-from-other-openssl-generated-key-file)**.
+It allows connecting to a HTTPS server with a untrusted/self-signed certificate.
 The value is not certificate of the server, but a certificate of the certificate authority used to generate the server certificate.
-You can define a single root certificate, or a bundle of root and intermediate certificates.
+You can define a single root certificate, or a bundle of root and intermediate certificates
+(see [EX141](https://github.com/keboola/generic-extractor/tree/master/doc/examples/141-https-self-signed)).
 
 ## Pagination
 Pagination (or scrolling) **describes how the API pages through a large set of results**. Because

--- a/extend/generic-extractor/configuration/api/index.md
+++ b/extend/generic-extractor/configuration/api/index.md
@@ -20,6 +20,7 @@ A sample API configuration can look like this:
     ...,
     "api": {
         "baseUrl": "https://example.com/v3.0/",
+        "caCertificate": "-----BEGIN CERTIFICATE-----\nMIIFaz....",
         "pagination": {
             "method": "offset",
             "offsetParam": "offset",
@@ -52,6 +53,12 @@ The `baseUrl` configuration **defines the URL to which the API requests should b
 recommend that the URL ends with a slash so that the `jobs.endpoint` can be set easily.
 See the [`endpoint` configuration](/extend/generic-extractor/configuration/config/jobs/#endpoint) for a detailed description of
 how `api.baseUrl` and `jobs.endpoint` work together.
+
+## CA certificate
+The `caCertificate` configuration **defines custom certificate authority bundle in `crt`/`pem` format**.
+It makes possible connection to a server with a untrusted/self-signed certificate.
+The value is not certificate of the server, but a certificate of the certificate authority used to generate the server certificate.
+You can define a single root certificate, or a bundle of root and intermediate certificates.
 
 ## Pagination
 Pagination (or scrolling) **describes how the API pages through a large set of results**. Because

--- a/extend/generic-extractor/configuration/configuration.md
+++ b/extend/generic-extractor/configuration/configuration.md
@@ -20,6 +20,7 @@ nesting. The **configuration map** is also available as a [separate article](/ex
 	- [**api**](/extend/generic-extractor/configuration/api/) --- sets the basic properties of the API.
 		- [**baseUrl**](/extend/generic-extractor/configuration/api/#base-url) --- defines the URL to which the
 		API requests should be sent.
+		- [**caCertificate**](/extend/generic-extractor/configuration/api/#ca-certificate) --- defines custom certificate authority bundle in `crt`/`pem` format.
 		- [**pagination**](/extend/generic-extractor/configuration/api/pagination/) --- breaks a result with a
 		large number of items into separate pages.
 		- [**authentication**](/extend/generic-extractor/configuration/api/authentication/) --- needs to be


### PR DESCRIPTION
Solving: https://keboola.atlassian.net/browse/COM-395
PR in generic-extractor: https://github.com/keboola/generic-extractor/pull/126

Changes:
- Added `api.caCertificate` parameter to generic-extractor.