### PR TITLE
Remove genericDockerUI-runtime info

### DIFF
--- a/extend/component/ui-options/index.md
+++ b/extend/component/ui-options/index.md
@@ -134,6 +134,3 @@ The configuration provided in this input is available in the `authorization` sec
 ## genericTemplatesUI
 This flag is used to provide a UI for components based on the [Generic Extractor](/extend/generic-extractor/). It allows the end user to select a
 [Generic Extractor template](/extend/generic-extractor/publish/).
-
-## genericDockerUI-runtime
-This flag is **deprecated**. It provides a UI for setting parameters for Custom Science.


### PR DESCRIPTION
Vyhazuje se to z UI - https://github.com/keboola/kbc-ui/pull/5191
A také z developer portálu - https://github.com/keboola/developer-portal-ui/pull/634