### PR TITLE
Generix extractor add api.#clientCertificate docs

### DIFF
--- a/extend/generic-extractor/configuration/api/index.md
+++ b/extend/generic-extractor/configuration/api/index.md
@@ -62,6 +62,24 @@ The value is not certificate of the server, but a certificate of the certificate
 You can define a single root certificate, or a bundle of root and intermediate certificates
 (see [EX141](https://github.com/keboola/generic-extractor/tree/master/doc/examples/141-https-self-signed)).
 
+## Client certificate
+The `#clientCertificate` configuration **defines the client certificate and private key**. This is required
+if the server requires two-way SSL authentication, so in addition to the verification of the server,
+the server also verifies the client (see [EX142](https://github.com/keboola/generic-extractor/tree/master/doc/examples/142-https-client-cert)).
+
+**Value is the client certificate, followed by the private key. Both
+in [`crt`/`pem` format](https://serverfault.com/questions/9708/what-is-a-pem-file-and-how-does-it-differ-from-other-openssl-generated-key-file)**.
+
+Example:
+```json
+{
+  "api": {
+    "baseUrl": "https://my-server.com",
+    "#clientCertificate": "-----BEGIN CERTIFICATE-----\n...\n----END CERTIFICATE-----\n-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----\n"
+  }
+}
+```
+
 ## Pagination
 Pagination (or scrolling) **describes how the API pages through a large set of results**. Because
 there are many different pagination strategies, the configuration is described on a

--- a/extend/generic-extractor/configuration/configuration.md
+++ b/extend/generic-extractor/configuration/configuration.md
@@ -21,6 +21,7 @@ nesting. The **configuration map** is also available as a [separate article](/ex
 		- [**baseUrl**](/extend/generic-extractor/configuration/api/#base-url) --- defines the URL to which the
 		API requests should be sent.
 		- [**caCertificate**](/extend/generic-extractor/configuration/api/#ca-certificate) --- defines custom certificate authority bundle in `crt`/`pem` format.
+		- [**#clientCertificate**](/extend/generic-extractor/configuration/api/#client-certificate) --- defines client certificate and private key in `crt`/`pem` format.
 		- [**pagination**](/extend/generic-extractor/configuration/api/pagination/) --- breaks a result with a
 		large number of items into separate pages.
 		- [**authentication**](/extend/generic-extractor/configuration/api/authentication/) --- needs to be


### PR DESCRIPTION
Klient na ZD potrebuje specifikovat SSL `clientCertificate`, tak sme to tam so Zajcom implementovali:

- https://github.com/keboola/generic-extractor/pull/129
- https://github.com/keboola/generic-extractor/pull/130