### PR TITLE
Query auth - adding example with token cyphering

### DIFF
--- a/extend/generic-extractor/configuration/api/authentication/query.md
+++ b/extend/generic-extractor/configuration/api/authentication/query.md
@@ -49,8 +49,8 @@ configuration does not become a complete mess.
 
 See [example [EX077]](https://github.com/keboola/generic-extractor/tree/master/doc/examples/077-query-auth).
 
-## Configuration With Cyphered Token Example
-Usually you want the value used for authentication cyphered (the `api-token` parameter with the value 2267709 in our example), so you are not exposing it to other users and also not storing it in the configuration versions history. The following authentication configuration combined with the parameter defined in the `config` section does that (the value with the prefix `#` is cyphered upon saving the configuration):
+## Configuration With Encrypted Token Example
+Usually you want the value used for authentication encrypted (the `api-token` parameter with the value 2267709 in our example), so you are not exposing it to other users and also not storing it in the configuration versions history. The following authentication configuration combined with the parameter defined in the [`config`](https://developers.keboola.com/extend/generic-extractor/configuration/config/) section does that (the value with the prefix `#` is encrypted upon saving the configuration):
 
 {% highlight json %}
 {
@@ -72,3 +72,6 @@ Usually you want the value used for authentication cyphered (the `api-token` par
     }
 }
 {% endhighlight %}
+
+
+See [example [EX094]](https://github.com/keboola/generic-extractor/tree/master/doc/examples/094-function-config-headers).

--- a/extend/generic-extractor/configuration/api/authentication/query.md
+++ b/extend/generic-extractor/configuration/api/authentication/query.md
@@ -50,7 +50,7 @@ configuration does not become a complete mess.
 See [example [EX077]](https://github.com/keboola/generic-extractor/tree/master/doc/examples/077-query-auth).
 
 ## Configuration With Cyphered Token Example
-Usually you want the value used for authentication cyphered (`api-token` parameter with value 2267709 in our example), so you are not exposing it to other users and also not storing it in the configuration versions history. The following authentication configuration combined with parameter defined in `config` section does that (the value prefixed with `#` is cyphered upon saving the configuration):
+Usually you want the value used for authentication cyphered (the `api-token` parameter with the value 2267709 in our example), so you are not exposing it to other users and also not storing it in the configuration versions history. The following authentication configuration combined with the parameter defined in the `config` section does that (the value with the prefix `#` is cyphered upon saving the configuration):
 
 {% highlight json %}
 {

--- a/extend/generic-extractor/configuration/api/authentication/query.md
+++ b/extend/generic-extractor/configuration/api/authentication/query.md
@@ -48,3 +48,27 @@ However, we recommend using the `authentication` setting for credentials so that
 configuration does not become a complete mess.
 
 See [example [EX077]](https://github.com/keboola/generic-extractor/tree/master/doc/examples/077-query-auth).
+
+## Configuration With Cyphered Token Example
+Usually you want the value used for authentication cyphered (`api-token` parameter with value 2267709 in our example), so you are not exposing it to other users and also not storing it in the configuration versions history. The following authentication configuration combined with parameter defined in `config` section does that (the value prefixed with `#` is cyphered upon saving the configuration):
+
+{% highlight json %}
+{
+    "api": {
+        ...,
+        "authentication": {
+            "type": "query",
+            "query": {
+                "api-token": {
+                    "attr": "#token"
+                }
+            }
+        }
+    },
+    "config": {
+        ...,
+        "#token": "2267709" 
+        }
+    }
+}
+{% endhighlight %}


### PR DESCRIPTION
Osobně jsem několikrát řešil ticket, kdy se někdo ptá, jak zašifrovat token, který se posílá v rámci Query authentication (https://keboola.zendesk.com/agent/tickets/19761). Sám mám problémy to z dokumentace vyčíst a poslat někomu link, kde se to dozví. Proto si myslím, že by bylo fajn mít příklad rovnou u té autorizace.
@hhanova @odinuv