### PR TITLE
Remove version from API urls

### DIFF
--- a/overview/api/index.md
+++ b/overview/api/index.md
@@ -27,16 +27,16 @@ The main APIs for our components are:
 | [Provisioning API](https://provisioningapi.docs.apiary.io/#) | Provisioning is a service creating accounts for [sandboxes](https://help.keboola.com/manipulation/transformations/sandbox/), [transformations](https://help.keboola.com/manipulation/transformations/) and database writers. |
 | [Provisioning Management API](https://provisioningmanagementapi.docs.apiary.io/#) | API managing servers for [sandboxes](https://help.keboola.com/manipulation/transformations/sandbox/), [transformations](https://help.keboola.com/manipulation/transformations/). |
 | [Syrup Queue API](https://syrupqueue.docs.apiary.io/#) | Syrup Queue is a component managing [Jobs](/integrate/jobs/). Being replaced by Queue API. |
-| [Queue API](https://app.swaggerhub.com/apis-docs/keboola/job-queue-api/1.1.0) | Queue is a service for [running components](/extend/docker-runner/) and managing [Jobs](/integrated/jobs/). |
+| [Queue API](https://app.swaggerhub.com/apis-docs/keboola/job-queue-api) | Queue is a service for [running components](/extend/docker-runner/) and managing [Jobs](/integrated/jobs/). |
 | [OAuth Broker API](https://oauthapi3.docs.apiary.io/#) | OAuth Broker is a component managing [OAuth authorizations](/extend/common-interface/oauth/#authorize) of other components. |
 | [Orchestrator API](https://keboolaorchestratorv2api.docs.apiary.io/#) | Orchestrator is a component [automating and scheduling tasks](https://help.keboola.com/tutorial/automate/) in your project. |
-| [Importer API](https://app.swaggerhub.com/apis-docs/keboola/import/1.0.0) | [Importer](/integrate/storage/api/importer/) is a helper service for easy table imports |
+| [Importer API](https://app.swaggerhub.com/apis-docs/keboola/import) | [Importer](/integrate/storage/api/importer/) is a helper service for easy table imports |
 | [Developer Portal API](https://kebooladeveloperportal.docs.apiary.io/#) | Developer Portal is an application separated from KBC for [creating components](/extend/component/). |
 | [Billing API](https://keboolabillingapi.docs.apiary.io/#) | Billing API for Pay as You Go projects. |
 | [Workspaces API](https://sandboxes.keboola.com/documentation) | Workspaces API for V2 workspaces. |
-| [Synchronous Actions API](https://app.swaggerhub.com/apis/odinuv/sync-actions/1.0.0) | API to trigger [Synchronous Actions](/extend/common-interface/actions/). This is a partial replacement of Docker Runner API and may not be available on all stacks. |
-| [Scheduler API](https://app.swaggerhub.com/apis/odinuv/scheduler/1.0.0) | API to automate configurations (replacement for Orchestrator API) |
-| [Notifications API](https://app.swaggerhub.com/apis/odinuv/notifications-service/1.0.0) | API to subscribe to events - e.g. failed orchestrations (replacement for Orchestrator API) |
+| [Synchronous Actions API](https://app.swaggerhub.com/apis/odinuv/sync-actions) | API to trigger [Synchronous Actions](/extend/common-interface/actions/). This is a partial replacement of Docker Runner API and may not be available on all stacks. |
+| [Scheduler API](https://app.swaggerhub.com/apis/odinuv/scheduler) | API to automate configurations (replacement for Orchestrator API) |
+| [Notifications API](https://app.swaggerhub.com/apis/odinuv/notifications-service) | API to subscribe to events - e.g. failed orchestrations (replacement for Orchestrator API) |
 
 If you don't know which API to use, see our [integration guide](/integrate/). It describes different roles of the APIs and contains examples of commonly
 performed actions.


### PR DESCRIPTION
Vyhodil bych ty verze, pak to načítá vždy tu poslední.. `job-queue-api` má poslední 1.2.1 ty ostatní asi jsou furt 1.0.0 ale asi fajn takto aby se to nemuselo aktualizovat.