### PR TITLE
Fix brew upgrade (KAC-31)

### DIFF
--- a/cli/installation/index.md
+++ b/cli/installation/index.md
@@ -25,7 +25,7 @@ kbc --version
 Upgrade:
 
 ```bash
-brew reinstall keboola/keboola-cli/keboola-cli
+brew upgrade keboola-cli
 ```
 
 ## Debian / Ubuntu


### PR DESCRIPTION
V předchozím PR (https://github.com/keboola/developers-docs/pull/191) jsem fixnul tu instalaci na `brew tap` ale zapomněl jsem na upgrade.