### PR TITLE
federationToken as part of body

### DIFF
--- a/_includes/async-create.py
+++ b/_includes/async-create.py
@@ -17,10 +17,11 @@ print('\nCreating upload file')
 # Create a new file in Storage
 # See https://keboola.docs.apiary.io/#reference/files/upload-file
 response = requests.post(
-    'https://connection.keboola.com/v2/storage/files/prepare?federationToken=1',
+    'https://connection.keboola.com/v2/storage/files/prepare',
     data={
         'name': fileName,
-        'sizeBytes': os.stat(fileName).st_size
+        'sizeBytes': os.stat(fileName).st_size,
+        'federationToken': 1
     },
     headers={'X-StorageApi-Token': storageToken}
 )

--- a/integrate/storage/api/import-export.md
+++ b/integrate/storage/api/import-export.md
@@ -37,7 +37,7 @@ First create a file resource; to create a new file called
 [`new-file.csv`](/integrate/storage/new-table.csv) with `52` bytes, call:
 
 {% highlight bash %}
-curl --request POST --header "X-StorageApi-Token:storage-token" --form "name=new-file.csv" --form "sizeBytes=52"  https://connection.keboola.com/v2/storage/files/prepare?federationToken=1
+curl --request POST --header "X-StorageApi-Token:storage-token" --form "name=new-file.csv" --form "sizeBytes=52" --form "federationToken=1" https://connection.keboola.com/v2/storage/files/prepare
 {% endhighlight %}
 
 Which will return a response similar to this:


### PR DESCRIPTION
Podla dokumentacie https://keboola.docs.apiary.io/#reference/files/upload-file/create-file-resource je to v body, do nedavna to fungovalo aj v url ale pouzitim req obj sa tato vlastnost ktoru dovolovalo defaultne chovanie zendu odstranila. Bohuzial sme to mali aj zle v dokumentacii. Po tom ako mergnem tuto upravu postnem aj na status