### PR TITLE
Fix content overflowing styles

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -152,11 +152,17 @@ table {
 }
 
 .root {
+  overflow: auto;
+
   .container {
     &.main {
       background-color: $keboola-violet;
     }
   }
+}
+
+img {
+  max-width: 100% !important;
 }
 
 .header {


### PR DESCRIPTION
Jira issue: [UT-332](https://keboola.atlassian.net/browse/UT-332)
Relates to: https://github.com/keboola/connection-docs/pull/441

Fix overflowing content on mobile;

- Allow automatic overflow on main wrapper
- Limit width of all images to width of its parents

[UT-332]: https://keboola.atlassian.net/browse/UT-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ