### PR TITLE
Add missing reference for Buffer api to the list of APIs

### DIFF
--- a/overview/api/index.md
+++ b/overview/api/index.md
@@ -37,6 +37,7 @@ The main APIs for our components are:
 | [Synchronous Actions API](https://app.swaggerhub.com/apis/odinuv/sync-actions) | API to trigger [Synchronous Actions](/extend/common-interface/actions/). This is a partial replacement of Docker Runner API and may not be available on all stacks. |
 | [Scheduler API](https://app.swaggerhub.com/apis/odinuv/scheduler) | API to automate configurations (replacement for Orchestrator API) |
 | [Notifications API](https://app.swaggerhub.com/apis/odinuv/notifications-service) | API to subscribe to events - e.g. failed orchestrations (replacement for Orchestrator API) |
+| [Buffer API](https://buffer.keboola.com/v1/documentation/) | The Keboola Buffer API allows you to ingest small and frequent events into your project’s storage. |
 
 If you don't know which API to use, see our [integration guide](/integrate/). It describes different roles of the APIs and contains examples of commonly
 performed actions.


### PR DESCRIPTION
V listu [Our APIs](https://developers.keboola.com/overview/api/) chybí odkaz na Buffer API dokumentaci,