### PR TITLE
Data Streams - Fix json sample syntax

### DIFF
--- a/integrate/data-streams/tutorial/index.md
+++ b/integrate/data-streams/tutorial/index.md
@@ -39,7 +39,7 @@ To start ingesting events, you must first create a receiver. Send the following 
             "name": "template",
             "template": {
               "language": "jsonnet",
-              "content": "'#' + Body('issue.id') + ': ' + Body('issue.body', 'n/a')",
+              "content": "'#' + Body('issue.id') + ': ' + Body('issue.body', 'n/a')"
             }
           }
         ]


### PR DESCRIPTION
Related to: https://keboola.atlassian.net/browse/SUPPORT-5188

Typo in sample JSON. Before fix I was getting:
<img width="1039" alt="image" src="https://github.com/keboola/developers-docs/assets/903531/72fea876-3deb-4121-8b47-4ee2c7d1b303">
