### PR TITLE
docs 302

### DIFF
--- a/overview/api/index.md
+++ b/overview/api/index.md
@@ -35,7 +35,7 @@ The main APIs for our components are:
 | [Billing API](https://keboolabillingapi.docs.apiary.io/#) | Billing API for Pay as You Go projects. |
 | [Workspaces API](https://sandboxes.keboola.com/documentation) | Workspaces API for V2 workspaces. |
 | [Synchronous Actions API](https://app.swaggerhub.com/apis/odinuv/sync-actions) | API to trigger [Synchronous Actions](/extend/common-interface/actions/). This is a partial replacement of Docker Runner API and may not be available on all stacks. |
-| [Scheduler API](https://app.swaggerhub.com/apis/odinuv/scheduler) | API to automate configurations (replacement for Orchestrator API) |
+| [Scheduler API](https://app.swaggerhub.com/apis/odinuv/scheduler) | API to automate configurations |
 | [Notifications API](https://app.swaggerhub.com/apis/odinuv/notifications-service) | API to subscribe to events, e.g., failed orchestrations (replacement for Orchestrator API) |
 | [Templates API](https://templates.keboola.com/v1/documentation/) | The Keboola Templates API allows you to apply a [template](/cli/templates/). |
 | [Buffer API](https://buffer.keboola.com/v1/documentation/) | The Keboola Buffer API allows you to ingest small and frequent events into your project’s storage. |


### PR DESCRIPTION
docs 302
Removing "(replacement for Orchestrator API)" from Scheduler API description