### PR TITLE
Adding a note on Orchestrator V2 APi

### DIFF
--- a/overview/api/index.md
+++ b/overview/api/index.md
@@ -6,18 +6,17 @@ permalink: /overview/api/
 * TOC
 {:toc}
 
-All our [Keboola components](/overview/) have a public API on [apiary](https://apiary.io/). For sending requests to our
-API, we recommend either the Apiary Console or Postman Client. Most of our APIs take and produce data in JSON format.
-Many of them require a *Storage API token*, which is entered in the `X-StorageApi-Token` header.
+All our [Keboola components](/overview/) have a public API on [apiary](https://apiary.io/). We recommend using either the Apiary Console or Postman Client for sending requests to our
+API. Most of our APIs accept and return data in JSON format.
+Many of these APIs require a *Storage API token*, specified in the `X-StorageApi-Token` header.
 
 ## List of Keboola APIs
 
 All parts of the Keboola platform can be controlled via an API.
 The main APIs for our components are:
 
-|---
-| API | Description
-|-|-|-
+| API | Description |
+|---|---|
 | [Keboola Storage API](https://keboola.docs.apiary.io/) | [Storage](/integrate/storage/) is the main Keboola component storing all data. |
 | [Keboola Management API](https://keboolamanagementapi.docs.apiary.io/) | API managing Keboola projects and users (and notifications and features). |
 | [Encryption API](https://keboolaencryption.docs.apiary.io/#) | Provides [Encryption](/overview/encryption/). |
@@ -29,7 +28,7 @@ The main APIs for our components are:
 | [Syrup Queue API](https://syrupqueue.docs.apiary.io/#) | Syrup Queue is a component managing [Jobs](/integrate/jobs/). Being replaced by Queue API. |
 | [Queue API](https://app.swaggerhub.com/apis-docs/keboola/job-queue-api) | Queue is a service for [running components](/extend/docker-runner/) and managing [Jobs](/integrate/jobs/). |
 | [OAuth Broker API](https://oauthapi3.docs.apiary.io/#) | OAuth Broker is a component managing [OAuth authorizations](/extend/common-interface/oauth/#authorize) of other components. |
-| [Orchestrator API](https://keboolaorchestratorv2api.docs.apiary.io/#) | Orchestrator is a component [automating and scheduling tasks](https://help.keboola.com/tutorial/automate/) in your project. For legacy orchestrations only. For Orchestrator V2 please refer to [Storage API](/integrate/storage/). |
+| [Orchestrator API](https://keboolaorchestratorv2api.docs.apiary.io/#) | Orchestrator is a component used for [automating and scheduling tasks](https://help.keboola.com/tutorial/automate/) in your project. Note: This applies to legacy orchestrations only. For Orchestrator V2, please refer to the [Storage API](/integrate/storage/). |
 | [Importer API](https://app.swaggerhub.com/apis-docs/keboola/import) | [Importer](/integrate/storage/api/importer/) is a helper service for easy table imports |
 | [Developer Portal API](https://kebooladeveloperportal.docs.apiary.io/#) | Developer Portal is an application separated from Keboola for [creating components](/extend/component/). |
 | [Billing API](https://keboolabillingapi.docs.apiary.io/#) | Billing API for Pay as You Go projects. |
@@ -41,11 +40,11 @@ The main APIs for our components are:
 | [Buffer API](https://buffer.keboola.com/v1/documentation/) | The Keboola Buffer API allows you to ingest small and frequent events into your project’s storage. |
 | [Vault](https://vault.keboola.com/docs/swagger.yaml) | Service handling variables & credentials storage. |
 
-If you don't know which API to use, see our [integration guide](/integrate/). It describes different roles of the APIs and contains examples of commonly
+If you're unsure which API to use, refer to our [integration guide](/integrate/). It describes the roles of different APIs and contains examples of commonly
 performed actions.
 
 ## Stacks and Endpoints
-Keboola is available in multiple [stacks](https://help.keboola.com/overview/#stacks). These can be 
+Keboola is available in multiple [stacks](https://help.keboola.com/overview/#stacks), which can be 
 either multi-tenant or single-tenant. Current multi-tenant stacks are:
 
 - US Virginia AWS – [connection.keboola.com](https://connection.keboola.com/)
@@ -54,14 +53,14 @@ either multi-tenant or single-tenant. Current multi-tenant stacks are:
 - EU Ireland Azure – [connection.north-europe.azure.keboola.com](https://connection.north-europe.azure.keboola.com/)
 - EU Frankfurt GCP - [connection.europe-west3.gcp.keboola.com](https://connection.europe-west3.gcp.keboola.com/)
 
-Each stack is a completely independent instance of Keboola services.
+Each stack operates as an independent instance of Keboola services.
 In all the API documentation above, the AWS US stack is used.
 
-Single-tenant stacks are available for a single enterprise customer with a domain name 
-in form `connection.CUSTOMER_NAME.keboola.com`.
+Single-tenant stacks are available for a single enterprise customer, with a domain name 
+in the format `connection.CUSTOMER_NAME.keboola.com`.
 
 If you are using another stack, modify the endpoints accordingly.
-Otherwise you will obtain an `Invalid Token` or unauthorized errors. The *authoritative list* of available endpoints is provided by the [Storage API Index Call](https://keboola.docs.apiary.io/#reference/miscellaneous/api-index/component-list). The following is a sample response:
+Otherwise, you may encounter `Invalid Token` or unauthorized errors. The *authoritative list* of available endpoints is provided by the [Storage API Index Call](https://keboola.docs.apiary.io/#reference/miscellaneous/api-index/component-list). The following is a sample response:
 
 {% highlight json %}
 {
@@ -135,7 +134,7 @@ The services listed above are:
 - `oauth` --- [OAuth Manager Service](/extend/common-interface/oauth/)
 - `queue` --- [Service for Running Components](/extend/docker-runner/)
 - `billing` --- Service for Computing Credits
-- `encryption` --- Service for [Encryption](https://developers.keboola.com/overview/encryption/).
+- `encryption` --- Service for [Encryption](https://developers.keboola.com/overview/encryption/)
 - `sandboxes` --- Workspace Manager Service
 - `mlflow` --- MLFlow Models Manager Service
 - `scheduler` --- [Service for Configuring Schedules](https://developers.keboola.com/automate/set-schedule/)
@@ -208,15 +207,15 @@ and in application integrations, we strongly suggest using the above API call.
 | Workspaces / Sandboxes | `sandboxes`    | EU Frankfurt GCP | https://sandboxes.europe-west3.gcp.keboola.com      |
 
 
-**Important**: Each of the stacks also uses its own set of [IP addresses](https://help.keboola.com/extractors/ip-addresses/).
+***Important**: Each stack also uses its own set of [IP addresses](https://help.keboola.com/extractors/ip-addresses/).*
 
 ## Calling API
 
-There are several ways of sending requests to our APIs.
+There are several ways to send requests to our APIs:
 
 ### Apiary Console
 Send requests to our API directly from the Apiary console by clicking on **Switch to console** or **Try**.
-Then fill the request headers and parameters and **Call Resource**.
+Fill in the request headers and parameters, then click **Call Resource**.
 
 {: .image-popup}
 ![Apiary console](/overview/api/apiary-console.png)
@@ -225,7 +224,7 @@ The Apiary console is fine if you send API requests only occasionally. It requir
 however, it has no history and no other useful features.
 
 ### Postman Client
-[Postman](https://www.getpostman.com/) is a generic HTTP API client. Use it if you work with Keboola APIs on a more regular basis.
+[Postman](https://www.getpostman.com/) is a generic HTTP API client, suitable for more regular API work.
 We also provide a collection of [useful API calls](https://documenter.getpostman.com/view/3086797/kbc-samples/77h845D?version=latest#9b9f3e7b-de3b-4c90-bad6-a8760e3852eb) with examples.
 The collection contains code examples in various languages; the requests can also be imported into the Postman application.
 
@@ -233,10 +232,8 @@ The collection contains code examples in various languages; the requests can als
 ![Postman Docs](/overview/api/postman-import.png)
 
 ### cURL
-[cURL](https://curl.haxx.se/) is a common library used by many systems. There is also
-a [command-line interface (CLI)](https://curl.haxx.se/docs/manpage.html) available.
-You can use the cURL CLI to create simple scripts working with Keboola APIs. For example, to [Run a Job](/integrate/jobs/),
-use
+[cURL](https://curl.haxx.se/) is a common library with a [command-line interface (CLI)](https://curl.haxx.se/docs/manpage.html).
+You can use the cURL CLI to create simple scripts for interacting with Keboola APIs. For example, to [run a job](/integrate/jobs/):
 
 {% highlight shell %}
 curl --data "{\"config\": \"sampledatabase\"}" --header "X-StorageAPI-Token: YourStorageToken" https://syrup.keboola.com/keboola.ex-db-mysql/run

--- a/overview/api/index.md
+++ b/overview/api/index.md
@@ -29,7 +29,7 @@ The main APIs for our components are:
 | [Syrup Queue API](https://syrupqueue.docs.apiary.io/#) | Syrup Queue is a component managing [Jobs](/integrate/jobs/). Being replaced by Queue API. |
 | [Queue API](https://app.swaggerhub.com/apis-docs/keboola/job-queue-api) | Queue is a service for [running components](/extend/docker-runner/) and managing [Jobs](/integrate/jobs/). |
 | [OAuth Broker API](https://oauthapi3.docs.apiary.io/#) | OAuth Broker is a component managing [OAuth authorizations](/extend/common-interface/oauth/#authorize) of other components. |
-| [Orchestrator API](https://keboolaorchestratorv2api.docs.apiary.io/#) | Orchestrator is a component [automating and scheduling tasks](https://help.keboola.com/tutorial/automate/) in your project. For legacy orchestrations only. |
+| [Orchestrator API](https://keboolaorchestratorv2api.docs.apiary.io/#) | Orchestrator is a component [automating and scheduling tasks](https://help.keboola.com/tutorial/automate/) in your project. For legacy orchestrations only. For Orchestrator V2 please refer to [Storage API](/integrate/storage/). |
 | [Importer API](https://app.swaggerhub.com/apis-docs/keboola/import) | [Importer](/integrate/storage/api/importer/) is a helper service for easy table imports |
 | [Developer Portal API](https://kebooladeveloperportal.docs.apiary.io/#) | Developer Portal is an application separated from Keboola for [creating components](/extend/component/). |
 | [Billing API](https://keboolabillingapi.docs.apiary.io/#) | Billing API for Pay as You Go projects. |


### PR DESCRIPTION
Hey, I have just added a quick note here in relation to the ticket https://keboola.atlassian.net/browse/SUPPORT-7520. 
We should somehow make it more visible which API to use if the user wants to operate the Orchestrator V2... 