### PR TITLE
Fix table command link and update navigation structure

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -421,8 +421,6 @@ items:
                     title: branch
                   - url: /cli/commands/remote/create/bucket/
                     title: bucket
-                  - url: /cli/commands/remote/create/table/
-                    title: table
               - url: /cli/commands/remote/file/
                 title: file
                 items:

--- a/cli/index.md
+++ b/cli/index.md
@@ -59,7 +59,7 @@ At the moment, all [Storage](https://help.keboola.com/storage/) related operatio
 
 These commands can be used to manage the [buckets](https://help.keboola.com/storage/buckets/) and [tables](https://help.keboola.com/storage/tables/) in your project:
 - To create a new bucket, use the [create bucket](/cli/commands/remote/create/bucket/) command. 
-- To create a new table, use the [create table](/cli/commands/remote/create/table/) command.
+- To create a new table, use the [create table](/cli/commands/remote/table/create) command.
 
 The resulting [tables](https://help.keboola.com/storage/tables/) will be empty, so you may want to use:
 - The [table import](/cli/commands/remote/table/import/) command to import data. 

--- a/cli/templates/structure/jsonnet-files/index.md
+++ b/cli/templates/structure/jsonnet-files/index.md
@@ -104,6 +104,7 @@ Example:
   - GCP stacks (BigQuery backend): `keboola.wr-db-snowflake-gcs`
   - GCP stacks (Snowflake backend): `keboola.wr-db-snowflake-gcs-s3`
 - This function is not supported in the `inputs.jsonnet` because project backends are unknown before template loading.
+
 --------------------------------------
 
 **`HasProjectBackend(backend string) bool`**


### PR DESCRIPTION
Changes:

- Corrected the table command link to ensure functionality.
- Improved navigation structure by cleaning up redundant or unclear elements.

---

This PR fixes: 

invalid path:
<img width="772" alt="image" src="https://github.com/user-attachments/assets/de313465-02f5-4ec1-b1dd-885c833d6b05" />

removed table: 
<img width="229" alt="image" src="https://github.com/user-attachments/assets/b0aa182c-45f5-4bde-8e14-a4fec053acee" />


<img width="829" alt="image" src="https://github.com/user-attachments/assets/3b026895-78df-402e-87c6-d25f1bdd22ac" />

