### PR TITLE
Update Pull workflow frequency in documentation from every five minutes to every hour

### DIFF
--- a/cli/github-integration/index.md
+++ b/cli/github-integration/index.md
@@ -17,7 +17,7 @@ Secret `KBC_STORAGE_API_TOKEN` with your master token needs to be added to the G
 
 ## Pull
 
-The Pull workflow is set to run automatically every five minutes to [pull](/cli/commands/sync/pull/) the changes from 
+The Pull workflow is set to run automatically every hour to [pull](/cli/commands/sync/pull/) the changes from 
 the project in Keboola. If it finds any changes, it creates a commit to the repository.
 
 *Note: GitHub does not guarantee periodic running at exact times. The triggers may be delayed a few minutes 


### PR DESCRIPTION
This pull request includes a change to the `cli/github-integration/index.md` file. The change modifies the frequency of the Pull workflow from every five minutes to every hour.

* [`cli/github-integration/index.md`](diffhunk://#diff-aa326cf7b8b58bf63bb6d8cc45957b7eb7081473e11ef7449e3fe476a0fba0c1L20-R20): Updated the Pull workflow frequency to run every hour instead of every five minutes.

<!-- provide additional notes -->
