### PR TITLE
docs: add --skip-workflows flag documentation for kbc init command

### DIFF
--- a/cli/commands/sync/init/index.md
+++ b/cli/commands/sync/init/index.md
@@ -48,6 +48,9 @@ Sets `true` to the `allowTargetEnv` field in the [manifest.json](/cli/structure/
 `--ci-validate <bool>`
 : Create a workflow to validate all branches on change (default true)
 
+`--skip-workflows`
+: Skip the interactive GitHub workflow setup
+
 `-H, --storage-api-host <string>` 
 : Keboola instance URL, e.g., "connection.keboola.com"
 

--- a/cli/devops-use-cases/index.md
+++ b/cli/devops-use-cases/index.md
@@ -26,7 +26,7 @@ branches.
 
 #### Initialization
 
-1. First, let’s initialize a GitHub repository with a single main branch via the `kbc init --allow-target-env` command.
+1. First, let's initialize a GitHub repository with a single main branch via the `kbc init --allow-target-env --skip-workflows` command.
 
 - Fill in all parameters as usual.
 - Select only the main branch in this case.
@@ -93,7 +93,7 @@ the Dev/Prod Manager example use case. You can use this, for instance, to distri
 
 ### Tutorial
 
-1. First, let’s **create a GitHub repository** with a single main branch via the `kbc init --allow-target-env` command:
+1. First, let's **create a GitHub repository** with a single main branch via the `kbc init --allow-target-env --skip-workflows` command:
 
 - Fill in all parameters as usual.
 - Select only the main branch in this case.

--- a/cli/github-integration/index.md
+++ b/cli/github-integration/index.md
@@ -7,7 +7,8 @@ permalink: /cli/github-integration/
 {:toc}
 
 The tool can generate workflows for GitHub Actions within commands [init](/cli/commands/sync/init/) 
-and [workflows](/cli/commands/ci/workflows/).
+and [workflows](/cli/commands/ci/workflows/). For automated CI/CD scenarios, use the `--skip-workflows` flag 
+with the init command to bypass interactive workflow setup prompts.
 
 Secret `KBC_STORAGE_API_TOKEN` with your master token needs to be added to the GitHub 
 [secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).

--- a/cli/index.md
+++ b/cli/index.md
@@ -21,7 +21,7 @@ Keboola CLI can be used, for example, to:
 - Copy a [configuration](https://help.keboola.com/components) as a directory in the project and between projects. See the [persist](/cli/commands/local/persist/) command.
 - Apply all changes back to the project in a moment. See the [push](/cli/commands/sync/push/) command.
 - Manage project history in a git repository.
-- Automate the whole process in a CI/CD pipeline. See [GitHub Integration](/cli/github-integration/).
+- Automate the whole process in a CI/CD pipeline. See [GitHub Integration](/cli/github-integration/). Use the `--skip-workflows` flag during initialization to avoid interactive prompts in automated environments.
 - Merge and rebase Keboola Branches via Git. Learn more in the [Example Use Cases]() section.
 - Distribute a single project definition into multiple projects. See the [Example Use Cases]() section.
 - Multi-stage (and multi-project) environment management via Git. See the [Example Use Cases]() section. 


### PR DESCRIPTION
<!-- ask someone for review, if you are unsure who, ask hhanova -->

Jira issue(s): PSGO-1085

Document the `--skip-workflows` flag for the `kbc init` command across multiple sections of the CLI documentation to support automation use cases.

## Changes:

- **Command Reference**: Added `--skip-workflows` flag documentation to `/cli/commands/sync/init/` with description "Skip the interactive GitHub workflow setup"
- **GitHub Integration**: Enhanced introduction to mention the flag for automated CI/CD scenarios where interactive prompts should be avoided
- **DevOps Use Cases**: Updated automation examples to include `--skip-workflows` alongside `--allow-target-env` for non-interactive initialization
- **CLI Overview**: Enhanced automation bullet point to specifically mention the flag for avoiding interactive prompts in automated environments

---

## Additional Notes:

This addresses PR feedback requesting broader documentation of the `--skip-workflows` flag beyond just the command reference. The flag is particularly valuable for:
- CI/CD pipelines that need to run `kbc init` without human interaction
- Docker containers or automated scripts initializing projects programmatically  
- DevOps workflows setting up multiple projects automatically

**Review Focus Areas:**
- Verify the flag exists and behaves as documented (implementation found in `devin/PSGO-1085-1758283952` branch of keboola-as-code)
- Confirm that `--allow-target-env --skip-workflows` is a valid flag combination as shown in the DevOps examples
- Check that the automation scenarios described are realistic and helpful for users

Link to Devin run: https://app.devin.ai/sessions/284a918ddf04416ab475d38fcd206a2d  
Requested by: Martin Vasko (@Matovidlo)