### PR TITLE
Update status link for Keboola updates

### DIFF
--- a/404.md
+++ b/404.md
@@ -14,7 +14,7 @@ sitemap: false
 If you are looking for some other stuff that does not exist, you might want to visit:
 
 - [connection.keboola.com](https://connection.keboola.com) -- for logging in into Keboola
-- [status.keboola.com](http://status.keboola.com/) -- for getting Keboola Status updates (service status and changelog); we recommend subscribing to the feed or monitoring it in a Slack channel to keep up to date.
+- [keboolastatus.com](https://keboolastatus.com/) -- for getting Keboola Status updates (service status and changelog); we recommend subscribing to the feed or monitoring it in a Slack channel to keep up to date.
 - [help.keboola.com](https://help.keboola.com) -- for general help with using Keboola
 - [developers.keboola.com](https://developers.keboola.com) -- for developing a Keboola component
 - [blog.keboola.com](http://blog.keboola.com/) -- something to read for data analysts


### PR DESCRIPTION
## Release Notes 

Change links from status.keboola.com to keboolastatus.com.

## Plans for customer communication
None.

## Impact analysis
Change in page footer.

## Change type
Link URL

## Justification
New status page.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.