### PR TITLE
docs: fix broken Snowflake warehouse link in runtime backend.type

### DIFF
--- a/integrate/jobs/index.md
+++ b/integrate/jobs/index.md
@@ -244,7 +244,7 @@ Use the `forceRun` mode to run a configuration that is disabled. The `debug` can
 ### Job Runtime configuration
 You may provide runtime settings for a job. Runtime settings do not affect what the job does, they affect how the job does it. The available runtime settings are:
 
-- `backend.type` --- for Snowflake transformations this is the size of the [Snowflake warehouse](https://github.com/keboola/developers-docs/pull/380/changes) used for the job; otherwise it affects the [container size](https://help.keboola.com/transformations/python-plain/#dynamic-backends). Available values for backend type are `small`, `medium`, `large`.
+- `backend.type` --- for Snowflake transformations this is the size of the [Snowflake warehouse](https://help.keboola.com/transformations/snowflake-plain/#dynamic-backends) used for the job; otherwise it affects the [container size](https://help.keboola.com/transformations/python-plain/#dynamic-backends). Available values for backend type are `small`, `medium`, `large`.
 - `parallelism` --- runs [Configuration Rows](https://help.keboola.com/components/#configuration-rows) (if present in the configuration) in parallel. Allowed values are integer values and `infinity`, which runs all rows in parallel. When not specified, the rows are run sequentially.
 - `tag` --- runs the component with a specific version of code. This is mostly used during component development, testing and debugging.
 


### PR DESCRIPTION
## Why
The `backend.type` bullet in `integrate/jobs/index.md` (added in #380, commit af22485) links "Snowflake warehouse" to [the PR's own files-changed tab](https://github.com/keboola/developers-docs/pull/380/changes) instead of a doc; an accidental paste.

**See the bug live:** [Job Runtime configuration](https://developers.keboola.com/integrate/jobs/#job-runtime-configuration). The "Snowflake warehouse" link there currently lands on the GitHub PR diff.

## What
- Repoint to [help.keboola.com/transformations/snowflake-plain/#dynamic-backends](https://help.keboola.com/transformations/snowflake-plain/#dynamic-backends), the Snowflake parallel of the [container-size link](https://help.keboola.com/transformations/python-plain/#dynamic-backends) already used in that sentence. developers.keboola.com has no internal backend-size page; the repo links these topics to help.keboola.com.
