### PR TITLE
docs: AJDA-2897 remove obsolete SSE transport references from MCP page

### DIFF
--- a/integrate/mcp.md
+++ b/integrate/mcp.md
@@ -3,11 +3,6 @@ title: Keboola MCP Integration
 permalink: /integrate/mcp/
 ---
 
-<div class="alert alert-warning" role="alert">
-    <i class="fas fa-exclamation-triangle"></i>
-    <strong>SSE Transport Deprecation:</strong> The SSE transport for MCP Server will be deprecated on 01.04.2026. Please migrate to Streamable HTTP transport using <code>/mcp</code> endpoints instead of <code>/sse</code>. Streamable HTTP provides bidirectional streaming for improved performance and reliability.
-</div>
-
 > The Keboola MCP Server is available at [github.com/keboola/mcp-server](https://github.com/keboola/mcp-server).
 > If this integration works well for you, please consider giving the repository a ⭐️!
 
@@ -94,7 +89,7 @@ The Keboola MCP Server supports several core concepts of the Model Context Proto
 
 | Concept     | Supported | Notes                                                                                                  |
 |-------------|-----------|--------------------------------------------------------------------------------------------------------|
-| Transports  | ✅        | Supports `stdio` and `Streamable HTTP` (recommended) for client communication. SSE is deprecated and will be removed on 01.04.2026. |
+| Transports  | ✅        | Supports `stdio` and `Streamable HTTP` (recommended) for client communication. |
 | Prompts     | ✅        | Processes natural language prompts from MCP clients to interact with Keboola.                          |
 | Tools       | ✅        | Provides a rich set of tools for storage operations, component management, SQL execution, job control. |
 | Resources   | ❌        | Exposing Keboola project entities (data, configurations, etc.) as formal MCP Resources is not currently supported.      |
@@ -103,7 +98,7 @@ The Keboola MCP Server supports several core concepts of the Model Context Proto
 
 ## Tool Authorization and Access Control
 
-When connecting to the [Keboola MCP Server](/ai/mcp-server/) via HTTP-based transports (Streamable HTTP recommended; SSE is deprecated), you can control which tools are available to clients using HTTP headers. This is useful for restricting AI agent capabilities, enforcing compliance policies, or providing customer-specific access controls.
+When connecting to the [Keboola MCP Server](/ai/mcp-server/) via the Streamable HTTP transport, you can control which tools are available to clients using HTTP headers. This is useful for restricting AI agent capabilities, enforcing compliance policies, or providing customer-specific access controls.
 
 <div class="clearfix"></div><div class="alert alert-info">
 <b>Note:</b> Tool authorization headers only apply to HTTP-based transports. They are not available when using the <code>stdio</code> transport for local execution.


### PR DESCRIPTION
Linear issue: https://linear.app/keboola/issue/AJDA-2897/odstranit-zbyvajici-odkazy-na-apiary

Stacked on top of #386 (base is `odin/AJDA-2897-1`, not `main`).

The SSE transport deprecation deadline (01.04.2026) has passed, so the deprecation messaging on the MCP integration page is obsolete.

Changes:

- Remove the SSE deprecation warning banner at the top of `/integrate/mcp/`.
- Remove the remaining SSE mentions in the capabilities table and the tool-control section.

The page now documents only `stdio` and `Streamable HTTP` transports.

---

Note: this PR is stacked on #386 (which is stacked on #385). Merge #385 → #386 → this in order; GitHub will retarget the base automatically as each merges.