### PR TITLE
docs: AJDA-2897 repoint Storage API links to api.keboola.com

### DIFF
--- a/_includes/async-create.py
+++ b/_includes/async-create.py
@@ -15,7 +15,7 @@ tableName = 'my-new-table'
 print('\nCreating upload file')
 
 # Create a new file in Storage
-# See https://keboola.docs.apiary.io/#reference/files/upload-file/create-file-resource
+# See https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/files/prepare
 response = requests.post(
     'https://connection.keboola.com/v2/storage/files/prepare',
     data={
@@ -47,7 +47,7 @@ s3.Bucket(parsed['uploadParams']['bucket']).put_object(Key=parsed['uploadParams'
 print('\nCreating table')
 
 # Load data from file into the Storage table
-# See https://keboola.docs.apiary.io/#reference/tables/create-table-asynchronously/create-new-table-from-csv-file-asynchronously
+# See https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/buckets/-id-/tables-async
 response = requests.post(
     'https://connection.keboola.com/v2/storage/buckets/%s/tables-async' % bucketName,
     data={'name': tableName, 'dataFileId': fileId, 'delimiter': ',', 'enclosure': '"'},
@@ -62,7 +62,7 @@ if (parsed['status'] == 'error'):
 status = parsed['status']
 while (status == 'waiting') or (status == 'processing'):
     print('\nWaiting for import to finish')
-    # See https://keboola.docs.apiary.io/#reference/jobs/manage-jobs/job-detail
+    # See https://api.keboola.com/?service=storage#get-/v2/storage/jobs/-jobId-
     response = requests.get(parsed['url'], headers={'X-StorageApi-Token': storageToken})
     jobParsed = json.loads(response.content.decode('utf-8'))
     status = jobParsed['status']

--- a/automate/index.md
+++ b/automate/index.md
@@ -14,9 +14,9 @@ in the correct format, check for format inconsistencies, and choose different me
 operation you wish to perform on the data. The platform scales the needed resources automatically across various 
 types of data (structured, semi-structured, and non-structured) and processes.
 
-The whole environment tracks all the [operational metadata](https://keboola.docs.apiary.io/#reference/events) 
+The whole environment tracks all the [operational metadata](https://api.keboola.com/?service=storage#tag--Events) 
 and can be accessed without needing a server via APIs. This is useful when automating development, testing and 
-production run of data jobs with automatic controls of [pipelines](https://keboola.docs.apiary.io/#reference/development-branches).
+production run of data jobs with automatic controls of [pipelines](https://api.keboola.com/?service=storage#get-/v2/storage/dev-branches/-id-).
 
 As Storage API is part of the wider Keboola platform, it is an essential element in providing coherent data 
 fabric across clouds, users, services, and on premise.

--- a/automate/set-schedule.md
+++ b/automate/set-schedule.md
@@ -23,7 +23,7 @@ config: 493493
 ```
 
 To create a schedule, you have to create the schedule configuration first using the 
-[Create Configuration API call](https://keboola.docs.apiary.io/#reference/components-and-configurations/component-configurations/create-configuration).
+[Create Configuration API call](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/components/-componentId-/configs).
 With the contents similar to this:
 
 ```json

--- a/cli/devops-use-cases/index.md
+++ b/cli/devops-use-cases/index.md
@@ -104,7 +104,7 @@ the Dev/Prod Manager example use case. You can use this, for instance, to distri
 2. **Obtain the main branch ID**:
 
    To get the destination project main branch ID, you can use
-   the [List Branches API call](https://keboola.docs.apiary.io/#reference/development-branches/branches/list-branches)
+   the [List Branches API call](https://api.keboola.com/?service=storage#get-/v2/storage/dev-branches)
    and search for a branch named `main`.
 
    Alternatively, from any component configuration, go to the Developer Tools (`F12` in Chrome)

--- a/extend/common-interface/config-file.md
+++ b/extend/common-interface/config-file.md
@@ -102,8 +102,8 @@ When working with the API, note that the [Developer Portal API](https://api.kebo
 (specifically the [Component Detail API call](https://api.keboola.com/?service=developer-portal#get-/vendors/-vendor-/apps/-app-))
 shows separate `stack_parameters` and `image_parameters`, because the API is region agnostic.
 
-However, when working with the [Storage API](https://keboola.docs.apiary.io/)
-(specifically the [Component list API call](https://keboola.docs.apiary.io/#reference/miscellaneous/api-index/component-list)),
+However, when working with the [Storage API](https://api.keboola.com/?service=storage)
+(specifically the [Component list API call](https://api.keboola.com/?service=storage#get-/v2/storage)),
 the `stack_parameters` and `image_parameters` values are already merged and only those designated for the
 current region are visible.
 
@@ -139,13 +139,13 @@ configurations, `KBC::ProjectSecure::` ciphers are used.
 
 ### State File Properties
 Because the state is stored as part of a
-[component configuration](https://keboola.docs.apiary.io/#reference/components-and-configurations),
+[component configuration](https://api.keboola.com/?service=storage#tag--Component-Configurations),
 the value of the state object is somewhat limited (should not generally exceed 1MB). It should not
 be used to store large amounts of data.
 
 Also, the end-user cannot easily access the data through the UI.
 The data can be, however, modified outside of the component itself using the
-[component configuration](https://keboola.docs.apiary.io/#reference/components-and-configurations) API calls.
+[component configuration](https://api.keboola.com/?service=storage#tag--Component-Configurations) API calls.
 Note however that the content in the contents of the state file is nested:
 
 I.e., assume that the component generates a state file with the following contents:
@@ -391,7 +391,7 @@ Download 2 days of data from the `in.c-storage.StoredData` table to `/data/table
 {% endhighlight %}
 
 #### Input mapping --- column types
-This is applicable only to [workspace mapping](/extend/common-interface/folders/#exchanging-data-via-workspace), for CSV files this setting has no effect. The `column_types` setting maps to [Storage API load options](https://keboola.docs.apiary.io/#reference/workspaces/load-data/load-data). It also acts the same way as `columns` setting allowing you to limit the table columns.
+This is applicable only to [workspace mapping](/extend/common-interface/folders/#exchanging-data-via-workspace), for CSV files this setting has no effect. The `column_types` setting maps to [Storage API load options](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/workspaces/-workspaceId-/load). It also acts the same way as `columns` setting allowing you to limit the table columns.
 If both `column_types` and `columns` setting are used, then the listed columns must match. If you omit `columns` and use only `column_types` (recommended) then `columns` will be propagated automatically from `column_types`.
 
 {% highlight json %}

--- a/extend/common-interface/development-branches.md
+++ b/extend/common-interface/development-branches.md
@@ -50,6 +50,6 @@ certain jobs in development branches based on the component’s features:
 * **dev-branch-job-blocked**: These components are not permitted to run in development branches under any circumstances.
 * **dev-mapping-allowed**: These components are allowed to use development buckets in their default branch input mappings, which is typically restricted. 
 
-For details on a component’s features, you can consult the [Developer Portal API](https://api.keboola.com/?service=developer-portal#get-/apps/-app-) or the [Component List in Storage API](https://keboola.docs.apiary.io/#reference/miscellaneous/api-index/component-list). 
+For details on a component’s features, you can consult the [Developer Portal API](https://api.keboola.com/?service=developer-portal#get-/apps/-app-) or the [Component List in Storage API](https://api.keboola.com/?service=storage#get-/v2/storage). 
 
 To request changes to your component's features, please use the support button in your project to contact our support team. 

--- a/extend/common-interface/environment.md
+++ b/extend/common-interface/environment.md
@@ -22,7 +22,7 @@ The following environment variables are injected into the container:
  - `KBC_CONFIGVERSION`: The version of the configuration, or empty if unnamed (when `configData` is used in the [API call](https://api.keboola.com/?service=job-queue#post-/jobs)).
  - `KBC_COMPONENTID`: The ID of the component.
  - `KBC_CONFIGROWID`: The ID of the configuration row, if available.
- - `KBC_BRANCHID`: The ID of the [development branch](https://keboola.docs.apiary.io/#reference/development-branches/branches).
+ - `KBC_BRANCHID`: The ID of the [development branch](https://api.keboola.com/?service=storage#get-/v2/storage/dev-branches/-id-).
  - `KBC_STAGING_FILE_PROVIDER`: Either `aws` or `azure`, depending on the type of [stack](/overview/api/#regions-and-endpoints) the container is running. This value refers to the file storage used during [file import/export operations](https://developers.keboola.com/integrate/storage/api/import-export/).
  - `KBC_PROJECT_FEATURE_GATES`: A comma-separated list of feature gates activated for the current project. Feature gates are considered internal and may change or disappear without notice. We recommend checking with our support team before relying on any feature gates.
  - `KBC_COMPONENT_RUN_MODE`: Either `run` or `debug`. The value `debug` is used when the job is run in debug mode ([learn more](https://developers.keboola.com/extend/component/running/#debugging)). This variable can be helpful, for example, to enable more verbose logging.

--- a/extend/common-interface/folders.md
+++ b/extend/common-interface/folders.md
@@ -210,7 +210,7 @@ are always saved to the directory structure.
 *Note: this is a preview feature and may change considerably in future.*
 *Note: currently only Azure Blob Storage workspaces (abs-workspace) are supported for this type and those only work with Synapse storage backend
 
-The component may also exchange data with a provisioned file workspace (Azure Blob Storage) [using Workspaces](https://keboola.docs.apiary.io/#reference/workspaces).
+The component may also exchange data with a provisioned file workspace (Azure Blob Storage) [using Workspaces](https://api.keboola.com/?service=storage#tag--Workspaces).
 This mode of operation can be enabled by setting the **Staging storage input** or **Staging storage output** option
 to **Workspace ABS**. A filesystem workspace is an isolated file storage to which data are loaded before the component job is run (when staging storage input is set)
 and unloaded from when the job finishes (when staging storage output is set).

--- a/extend/common-interface/logging.md
+++ b/extend/common-interface/logging.md
@@ -26,7 +26,7 @@ By default -- unless you have turned on [GELF logging](/extend/common-interface/
 [component configuration](https://components.keboola.com/),
 [Job Queue](/extend/job-queue/) listens to [STDOUT](https://en.wikipedia.org/wiki/Standard_streams#Standard_output_.28stdout.29)
 and [STDERR](https://en.wikipedia.org/wiki/Standard_streams#Standard_error_.28stderr.29)
-of the component and forwards the STDOUT content live to [Storage API Events](https://keboola.docs.apiary.io/#reference/events)
+of the component and forwards the STDOUT content live to [Storage API Events](https://api.keboola.com/?service=storage#tag--Events)
 (log level `info`). The content of STDERR is collected and added (if not empty) as the last event of the job with level `error`.
 The events are displayed in a [Job detail](https://help.keboola.com/management/jobs/).
 

--- a/extend/common-interface/manifest-files/in-tables-manifests.md
+++ b/extend/common-interface/manifest-files/in-tables-manifests.md
@@ -33,5 +33,7 @@ contents:
 {% endhighlight %}
 
 The `name` node refers to the name of the component configuration.
-The `metadata` and `column_metadata` fields contains
-[Metadata](https://keboola.docs.apiary.io/#reference/metadata) for the table and its columns.
+The `metadata` and `column_metadata` fields contain
+Metadata for the table and its columns.
+The `metadata` field corresponds to the [Table Metadata API call](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/tables/-id-/metadata).
+The `column_metadata` field corresponds to the [Column Metadata API call](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/columns/-id-/metadata).

--- a/extend/common-interface/manifest-files/out-files-manifests.md
+++ b/extend/common-interface/manifest-files/out-files-manifests.md
@@ -20,7 +20,7 @@ manifest fields; all of them are optional.
 }
 {% endhighlight %}
 
-These parameters can be used (taken from [Storage API File Import](https://keboola.docs.apiary.io/#reference/files/upload-file/create-file-resource)):
+These parameters can be used (taken from [Storage API File Import](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/files/prepare)):
 
 - If `is_permanent` is false, the file will be automatically deleted after 15 days.
 - When `notify` is true, the members of the project will be notified that a file has been uploaded to the project.

--- a/extend/common-interface/manifest-files/out-tables-manifests-native-types.md
+++ b/extend/common-interface/manifest-files/out-tables-manifests-native-types.md
@@ -31,8 +31,8 @@ from the file name; it can (and commonly is) overridden by the end-user configur
 {% endhighlight %}
 
 The `table_metadata` fields allow you to set
-[Metadata](https://keboola.docs.apiary.io/#reference/metadata) for the table.
-The `table_metadata` field corresponds to the [Table Metadata API call](https://keboola.docs.apiary.io/#reference/metadata/table-metadata/create-or-update).
+Metadata for the table.
+The `table_metadata` field corresponds to the [Table Metadata API call](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/tables/-id-/metadata).
 The `key` and `value` of the object are passed directly to the API; the `provider` value is
 filled by the Id of the running component (e.g., `keboola.ex-db-snowflake`).
 
@@ -138,7 +138,7 @@ The data is converted only when writing or copying (e.g., to a transformation or
 That means that you can extract an *integer* column, mark it as a *timestamp* in storage and write it as
 an *integer* into a target database (though you'll be offered to write it as a timestamp).
 
-You access both the source and base data type through the corresponding [API](https://keboola.docs.apiary.io/#reference/tables/manage-tables/table-detail).
+You access both the source and base data type through the corresponding [API](https://api.keboola.com/?service=storage#get-/v2/storage/branch/-branchId-/tables/-id-).
 
 ## Nullable Conversion
 Nullable conversion, which transforms an empty string originating from data into a null value, refers to the process where a textual value consisting solely of an empty string `""` is replaced with the value null.

--- a/extend/common-interface/manifest-files/out-tables-manifests.md
+++ b/extend/common-interface/manifest-files/out-tables-manifests.md
@@ -47,9 +47,9 @@ table is imported. See an [example](/extend/common-interface/config-file/#output
 Using this option makes sense only with [incremental loads](/extend/generic-extractor/incremental/).
 
 The `metadata` and `column_metadata` fields allow you to set
-[Metadata](https://keboola.docs.apiary.io/#reference/metadata) for the table and its columns.
-The `metadata` field corresponds to the [Table Metadata API call](https://keboola.docs.apiary.io/#reference/metadata/table-metadata/create-or-update).
-The `column_metadata` field corresponds to the [Column Metadata API call](https://keboola.docs.apiary.io/#reference/metadata/column-metadata/create-or-update).
+Metadata for the table and its columns.
+The `metadata` field corresponds to the [Table Metadata API call](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/tables/-id-/metadata).
+The `column_metadata` field corresponds to the [Column Metadata API call](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/columns/-id-/metadata).
 In both cases, the `key` and `value` are passed directly to the API; the `provider` value is
 filled by the Id of the running component (e.g., `keboola.ex-db-snowflake`).
 

--- a/extend/component/code-patterns/tutorial.md
+++ b/extend/component/code-patterns/tutorial.md
@@ -88,7 +88,7 @@ You have created an empty transformation.
 
 **Set the code pattern to the transformation via [Storage API](/overview/api/).**
 
-Load the configuration in the JSON format via the [Configuration Detail](https://keboola.docs.apiary.io/#reference/components-and-configurations/manage-configurations/configuration-detail) API call.
+Load the configuration in the JSON format via the [Configuration Detail](https://api.keboola.com/?service=storage#get-/v2/storage/branch/-branchId-/components/-componentId-/configs/-configurationId-) API call.
 
 ```
 curl \ 
@@ -121,7 +121,7 @@ It is necessary to set the **ID of the code pattern component** to the configura
 }
 ```
 
-Update the configuration via the [Update Configuration](https://keboola.docs.apiary.io/#reference/components-and-configurations/manage-configurations/update-configuration) API call. 
+Update the configuration via the [Update Configuration](https://api.keboola.com/?service=storage#put-/v2/storage/branch/-branchId-/components/-componentId-/configs/-configurationId-) API call. 
 JSON must be url-encoded.
 
 ```

--- a/extend/component/index.md
+++ b/extend/component/index.md
@@ -92,9 +92,9 @@ The expected behavior of the above component types can be described in more deta
 - Transformation -- represents a transformation engine. The UI treats these components specially and expects that they have similar capabilities
 and configuration options. These are created by Keboola. If you wish to bring your own, please contact us first.
 - Other -- this component type has a special role in the UI, it has no standard component UI. Notable "other" components are:
-    - `keboola.variables` -- Component for storing [variables](/integrate/variables/) configurations. Use the standard [configurations API](https://keboola.docs.apiary.io/#reference/components-and-configurations). No jobs can be made.
+    - `keboola.variables` -- Component for storing [variables](/integrate/variables/) configurations. Use the standard [configurations API](https://api.keboola.com/?service=storage#tag--Component-Configurations). No jobs can be made.
     - `keboola.storage` -- Placeholder component for actions from Storage service. Neither configurations nor jobs can be made. Use the
-    [dedicated API](https://keboola.docs.apiary.io/) to work with Storage.
+    [dedicated API](https://api.keboola.com/?service=storage) to work with Storage.
 
 ## Next Steps
 - Create a [developer account](/extend/component/tutorial/#before-you-start) so that you can create your own components.

--- a/extend/component/processors.md
+++ b/extend/component/processors.md
@@ -21,7 +21,7 @@ convert the CSV to UTF-8 as expected by [Storage](https://help.keboola.com/stora
 
 Processors are technically supported in any configuration of any component. However, as an **advanced feature**, they have little to no 
 [support in the UI](/extend/component/ui-options/#genericdockerui-processors). To manually configure processors, 
-you have to use the [Component Configuration API](https://keboola.docs.apiary.io/#reference/components-and-configurations).
+you have to use the [Component Configuration API](https://api.keboola.com/?service=storage#tag--Component-Configurations).
 See the respective part of our [documentation](/integrate/storage/api/configurations/) for
 examples of working with the [Component Configuration API](/integrate/storage/api/configurations/).
 If you want to implement your own processor, see our [implementation notes](/extend/component/implementation/#implementing-processors).
@@ -29,12 +29,12 @@ If you want to implement your own processor, see our [implementation notes](/ext
 If the component does not contain the [respective configuration field](/extend/component/ui-options/#genericdockerui-processors) or
 an [advanced configuration mode](https://help.keboola.com/extractors/other/aws-s3/#advanced), processors are
 completely **invisible in the UI**. In such case, modifying the configuration through the UI may delete the processor configuration
-(though you can always [rollback](https://keboola.docs.apiary.io/#reference/components-and-configurations/rollback-configuration-version/rollback-version)).
+(though you can always [rollback](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/components/-componentId-/configs/-configurationId-/versions/-versionId-/rollback)).
 Therefore be sure to add an **appropriate warning** to the configuration description.
 
 ## Configuration
 By running the
-[Get Configuration Detail](https://keboola.docs.apiary.io/#reference/components-and-configurations/manage-configurations/configuration-detail)
+[Get Configuration Detail](https://api.keboola.com/?service=storage#get-/v2/storage/branch/-branchId-/components/-componentId-/configs/-configurationId-)
 request for a specific component ID and configuration ID, you obtain the actual configuration contents.
 You can see [an example request](https://documenter.getpostman.com/view/3086797/kbc-samples/77h845D?version=latest#9b9f3e7b-de3b-4c90-bad6-a8760e3852eb)
 for getting a configuration with ID `365111648` for the component called Email Attachments extractor (ID `keboola.ex-email-attachments`):
@@ -141,7 +141,7 @@ You can specify a particular version of the processor by adding an optional `tag
 
 If the tag parameter is omitted, the processor will automatically use the latest released version.
 
-To save the configuration, use the [Update Configuration API call](https://keboola.docs.apiary.io/#reference/components-and-configurations/manage-configurations/update-configuration).
+To save the configuration, use the [Update Configuration API call](https://api.keboola.com/?service=storage#put-/v2/storage/branch/-branchId-/components/-componentId-/configs/-configurationId-).
 When updating the configuration, you must provide `componentId`, `configurationId`, and the actual contents of
 the configuration in the `configuration` form field. Make sure to supply only the **contents** of the `configuration`
 node and to properly escape the form data.
@@ -185,7 +185,7 @@ and are described in the respective processor documentation.
 
 ### Using Processors with Configuration Rows
 If the configuration uses [Configuration Rows](/integrate/storage/api/configurations/#configuration-rows),
-you have to use the [Update Configuration Row](https://keboola.docs.apiary.io/#reference/components-and-configurations/manage-configuration-rows/update-row)
+you have to use the [Update Configuration Row](https://api.keboola.com/?service=storage#put-/v2/storage/branch/-branchId-/components/-componentId-/configs/-configurationId-/rows/-rowId-)
 API call to set the processors.
 
 Provide `componentId`, `configurationId`, `rowId` and the contents of the configuration in

--- a/extend/generic-extractor/incremental.md
+++ b/extend/generic-extractor/incremental.md
@@ -80,7 +80,7 @@ See [example [EX107]](https://github.com/keboola/generic-extractor/tree/master/d
 
 The last successful time is stored in the [configuration state](/extend/common-interface/config-file/#state-file).
 If for some reason you need to reset it, 
-[update the configuration via API](https://keboola.docs.apiary.io/#reference/components-and-configurations/manage-configurations/update-configuration).
+[update the configuration via API](https://api.keboola.com/?service=storage#put-/v2/storage/branch/-branchId-/components/-componentId-/configs/-configurationId-).
 
 ### Previous Start Date
 If an API similar to the one in the [above example](#previous-start-example) requires the date to be 

--- a/extend/job-queue/index.md
+++ b/extend/job-queue/index.md
@@ -14,7 +14,7 @@ represented by a Docker image.
 Running a component means creating and executing an [asynchronous job](/integrate/jobs/).
 
 Developing functionality in [Docker](https://www.docker.com/) allows you to focus only on the application logic; all communication
-with the [Storage API](https://keboola.docs.apiary.io/#) will be handled by Job Queue. You can encapsulate any application into a Docker image
+with the [Storage API](https://api.keboola.com/?service=storage) will be handled by Job Queue. You can encapsulate any application into a Docker image
 following a set of rules that will allow you to integrate the application into Keboola.
 
 There is a [predefined interface](/extend/common-interface/) with Job Queue, consisting
@@ -73,7 +73,7 @@ The [Job Queue API](https://api.keboola.com/?service=job-queue) has API calls to
 
 ## Configuration
 Components executed by Job Queue store their configurations in
-[Storage API components configurations](https://keboola.docs.apiary.io/#reference/components-and-configurations).
+[Storage API components configurations](https://api.keboola.com/?service=storage#tag--Component-Configurations).
 
 When creating the configuration, use
 [this JSON schema](https://github.com/keboola/docker-bundle/blob/master/Resources/schemas/configuration.json)
@@ -83,7 +83,7 @@ all of them are optional:
 - `parameters` --- an arbitrary object passed to the dockerized application itself
 - `storage` --- configuration of [input and output mapping](/extend/common-interface/folders/); specific options correspond to the options of the
 [unload data](https://keboola.docs.apiary.io/#reference/tables/unload-data-asynchronously) and
-[load data](https://keboola.docs.apiary.io/#reference/tables/load-data-asynchronously) API calls.
+[load data](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/tables/-id-/import-async) API calls.
 - `runtime` --- [runtime settings](/integrate/jobs/#job-runtime-configuration) (`tag`, `backend`, `parallelism`); most notably `runtime.tag`
 pins the Docker image tag that jobs of this configuration run, which is the usual way of testing a development build of a component
 - `processors` --- configuration of [Processors](/extend/component/processors/)

--- a/extend/publish/index.md
+++ b/extend/publish/index.md
@@ -11,7 +11,7 @@ redirect_from:
 
 As described in the [architecture overview](/overview/), Keboola consists of many different components.
 Only those components that are published in our **Component List** are generally available in Keboola.
-The list can be found in our [Storage Component API](https://keboola.docs.apiary.io/#) in the dedicated [Components section](https://keboola.docs.apiary.io/#reference/components-and-configurations/list-components).
+The list can be found in our [Storage Component API](https://api.keboola.com/?service=storage#get-/v2/storage) in the dedicated [Components section](https://api.keboola.com/?service=storage#get-/v2/storage).
 The list of components is managed using the Keboola [Developer Portal](https://components.keboola.com/).
 
 That being said, any Keboola user can use any component, unless
@@ -25,7 +25,7 @@ navigate you through creating an account in the [Developer Portal](https://compo
 
 ## Publishing Component
 A non-published component can be used without limitations, but it is not offered in the Keboola UI. It can only be used via
-the [API](https://keboola.docs.apiary.io/#reference/components-and-configurations) or by directly visiting a link with the 
+the [API](https://api.keboola.com/?service=storage#tag--Component-Configurations) or by directly visiting a link with the 
 specific component ID:
 
     https://connection.keboola.com/admin/projects/{PROJECT_ID}/extractors/{COMPONENT_ID}

--- a/integrate/artifacts/tutorial.md
+++ b/integrate/artifacts/tutorial.md
@@ -13,7 +13,7 @@ But these principles would work inside any component.
 In the examples, we use the `curl` console tool to interact with our APIs.
 
 *Note: `artifacts` feature needs to be enabled in your project. Please contact [support@keboola.com](mailto:support@keboola.com) to enable the feature in your project*
-*Note 2: `artifacts` configuration can be created or edited only via [Configuration API](https://keboola.docs.apiary.io/#reference/components-and-configurations/component-configurations/create-configuration) for now*
+*Note 2: `artifacts` configuration can be created or edited only via [Configuration API](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/components/-componentId-/configs) for now*
 
 ## Examples
 

--- a/integrate/jobs/index.md
+++ b/integrate/jobs/index.md
@@ -218,18 +218,18 @@ To create a job, you must provide the [configuration](https://help.keboola.com/c
 
 A configuration can be provided in multiple ways. The easiest is to provide a reference to 
 a stored configuration ID using the `config` field as shown above. Configurations can be stored and listed using the 
-[Component Configurations API endpoint](https://keboola.docs.apiary.io/#reference/components-and-configurations/component-configurations/list-configurations).
+[Component Configurations API endpoint](https://api.keboola.com/?service=storage#get-/v2/storage/branch/-branchId-/components/-componentId-/configs).
 When using a configuration which contains [Configuration Rows](https://help.keboola.com/components/#configuration-rows), the job can optionally execute 
 only certain rows. Use the `configRowIds` field to list row IDs to execute. Note that if you do not list any rows, then all rows will be executed except 
 for disabled rows. When you enumerate rows to execute, then the enumerated rows will be executed even if they are disabled. To run a job of 
-a configuration in a branch, provide the [branch ID](https://keboola.docs.apiary.io/#reference/development-branches/branches/list-branches) 
+a configuration in a branch, provide the [branch ID](https://api.keboola.com/?service=storage#get-/v2/storage/dev-branches) 
 in the `branchId` field. If you do not provide `branchId`, then the default branch is used. 
 Take care that only the **combination of component ID, configuration ID and branch ID is unique**. It is possible for two configurations with the 
 same ID to exist (either for different component or for a different branch).
 
 Another option is to provide the entire configuration in the `configData` field. In that case the whole configuration data
 has to be provided in the request. If you are retrieving a 
-[stored configuration](https://keboola.docs.apiary.io/#reference/components-and-configurations/manage-configurations/configuration-detail), take 
+[stored configuration](https://api.keboola.com/?service=storage#get-/v2/storage/branch/-branchId-/components/-componentId-/configs/-configurationId-), take 
 note that the configuration data is the contents of the `configuration` node and not the entire 
 response. When using the `configData` field, the `configRowIds` and `branchId` values are ignored. When using the `configData` field the `config` field 
 is ignored for the purpose of reading the configuration, but may still be required in case the component is using 
@@ -286,8 +286,8 @@ behavior can be further controlled by the `onError` setting. You cannot specify 
 The main API to run the jobs is [Job Queue API](https://app.swaggerhub.com/apis-docs/keboola/job-queue-api). There are some API calls from other services 
 which might be useful when working with jobs:
 
-- [Create configurations](https://keboola.docs.apiary.io/#reference/components-and-configurations/component-configurations/create-configuration)
-- [List Job Events](https://keboola.docs.apiary.io/#reference/events/events/events-list)
+- [Create configurations](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/components/-componentId-/configs)
+- [List Job Events](https://api.keboola.com/?service=storage#get-/v2/storage/branch/-branchId-/events)
 - [Encrypt values](https://api.keboola.com/?service=encryption#post-/encrypt)
 - [Run Synchronous Actions](https://app.swaggerhub.com/apis/odinuv/sync-actions/1.0.0#/default/post_actions)
 - [Subscribe to Job Events](https://app.swaggerhub.com/apis/odinuv/notifications-service/1.1.0#/Project%20Subscriptions/createSubscription)
@@ -296,14 +296,14 @@ which might be useful when working with jobs:
 The component jobs are asynchronous operations, this means that you create it and then you have to actively wait for the result. Note that there 
 are other *unrelated* cases of asynchronous operations in Keboola Platform which are in principle the same, but may differ in little details. 
 The most common one is:
-[Storage Jobs](https://keboola.docs.apiary.io/#reference/jobs/manage-jobs/job-detail), triggered, for instance, by
-[asynchronous imports](https://keboola.docs.apiary.io/#reference/tables/create-table-asynchronously/create-new-table-from-csv-file-asynchronously)
+[Storage Jobs](https://api.keboola.com/?service=storage#get-/v2/storage/jobs/-jobId-), triggered, for instance, by
+[asynchronous imports](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/buckets/-id-/tables-async)
 or [exports](https://keboola.docs.apiary.io/#reference/tables/unload-data-asynchronously/asynchronous-export)
 
 ### Run a Job
 You need to know the *component Id* and *configuration Id* to create a job. You can get these from the UI links. To use the API to obtain a 
 list of all components available in the project, and their configuration, you can use the
-[Get components](https://keboola.docs.apiary.io/#reference/components-and-configurations/list-components/get-components).
+[Get components](https://api.keboola.com/?service=storage#get-/v2/storage).
 See an [example](https://documenter.getpostman.com/view/3086797/kbc-samples/77h845D?version=latest#9b9f3e7b-de3b-4c90-bad6-a8760e3852eb).
 A snippet of the response is below:
 

--- a/integrate/storage/api/configurations.md
+++ b/integrate/storage/api/configurations.md
@@ -13,10 +13,10 @@ Configurations represent component **instances** in a project. Each Keboola comp
 options and requirements, which must be respected. As such, Keboola configurations provide a general framework for configuring
 components, while the specific implementation details are left to the components themselves.
 
-When working with the [Component Configurations API](https://keboola.docs.apiary.io/#reference/components-and-configurations),
+When working with the [Component Configurations API](https://api.keboola.com/?service=storage#tag--Component-Configurations),
 you need to know the `componentId` of the component being configured.
 You can see a list of public components in [the Developer Portal](https://components.keboola.com/components), or you can get
-a list of all available components with the [API index call](https://keboola.docs.apiary.io/#reference/miscellaneous/api-index/component-list).
+a list of all available components with the [API index call](https://api.keboola.com/?service=storage#get-/v2/storage).
 See our [example](https://documenter.getpostman.com/view/3086797/kbc-samples/77h845D?version=latest#9b9f3e7b-de3b-4c90-bad6-a8760e3852eb).
 
 It will give you something like this:
@@ -27,7 +27,7 @@ It will give you something like this:
     "api": "storage",
     "version": "v2",
     "revision": "21fb56a0f6d61a307f350247a45950b1e4049625",
-    "documentation": "https://keboola.docs.apiary.io/",
+    "documentation": "https://connection.keboola.com/api/storage/doc.json",
     "components": [
         {
             "id": "keboola.ex-aws-s3",
@@ -94,7 +94,7 @@ a bit tricky. Rather than starting from scratch, we recommend creating a configu
 
 ### Inspecting Configuration
 To obtain an existing configuration, you can either use the list of configurations above or
-the [Configuration Detail](https://keboola.docs.apiary.io/#reference/components-and-configurations/manage-configurations/configuration-detail)
+the [Configuration Detail](https://api.keboola.com/?service=storage#get-/v2/storage/branch/-branchId-/components/-componentId-/configs/-configurationId-)
 API call. See an [example](https://documenter.getpostman.com/view/3086797/kbc-samples/77h845D?version=latest#9b9f3e7b-de3b-4c90-bad6-a8760e3852eb) for obtaining a
 configuration of the `keboola.ex-aws-s3` component. You will receive a response similar to this:
 
@@ -299,10 +299,10 @@ not used.
 
 ## Working with Configurations
 Here, the most common operations done with configurations are described in examples. Feel free to go through the
-[API reference](https://keboola.docs.apiary.io/#reference/components-and-configurations) for a full authoritative list of configuration features.
+[API reference](https://api.keboola.com/?service=storage#tag--Component-Configurations) for a full authoritative list of configuration features.
 
 ### List Configurations
-To obtain configuration details, use the [List Configs call](https://keboola.docs.apiary.io/#reference/components-and-configurations/component-configurations/list-configurations),
+To obtain configuration details, use the [List Configs call](https://api.keboola.com/?service=storage#get-/v2/storage/branch/-branchId-/components/-componentId-/configs),
 which will return all the configuration details. This means
 
 - the configuration itself (`configuration`) --- [section on configuration](#modifying-a-configuration) follows;
@@ -370,7 +370,7 @@ A sample result for the AWS S3 extractor looks like this:
 
 Modifying a configuration means that a new version of that configuration is created.
 For modifying a configuration, use the
-[Update Configuration](https://keboola.docs.apiary.io/#reference/components-and-configurations/manage-configurations/update-configuration) API call.
+[Update Configuration](https://api.keboola.com/?service=storage#put-/v2/storage/branch/-branchId-/components/-componentId-/configs/-configurationId-) API call.
 See an [example](https://documenter.getpostman.com/view/3086797/kbc-samples/77h845D?version=latest#9b9f3e7b-de3b-4c90-bad6-a8760e3852eb) in which the
 configuration is modified to the following to set new credentials:
 
@@ -411,7 +411,7 @@ for the exact example request.
 ### Modifying Configuration Row
 Very similar to modifying a configuration, modifying a configuration **row** means that a new version of
 the **entire configuration** is created. For modifying a configuration row, use the
-[Update Row](https://keboola.docs.apiary.io/#reference/components-and-configurations/manage-configuration-rows/update-configuration-row) API call.
+[Update Row](https://api.keboola.com/?service=storage#put-/v2/storage/branch/-branchId-/components/-componentId-/configs/-configurationId-/rows/-rowId-) API call.
 
 See an [example](https://documenter.getpostman.com/view/3086797/kbc-samples/77h845D?version=latest#9b9f3e7b-de3b-4c90-bad6-a8760e3852eb) in which the
 configuration row is modified to:
@@ -434,10 +434,10 @@ in the root `configuration` and row `configuration`, the values from the row are
 state by setting `state` to `{}`.
 
 ### Configuration Versions
-When you [update a configuration](https://keboola.docs.apiary.io/#reference/components-and-configurations/manage-configurations/update-configuration),
+When you [update a configuration](https://api.keboola.com/?service=storage#put-/v2/storage/branch/-branchId-/components/-componentId-/configs/-configurationId-),
 a new configuration version is actually created. In the above calls, only the last (active/published) configuration
 is returned. To obtain a list of all recorded versions, use the
-[List Versions API call](https://keboola.docs.apiary.io/#reference/components-and-configurations/list-configuration-versions/versions-list).
+[List Versions API call](https://api.keboola.com/?service=storage#get-/v2/storage/branch/-branchId-/components/-componentId-/configs/-configurationId-/versions).
 See this [example](https://documenter.getpostman.com/view/3086797/kbc-samples/77h845D?version=latest#9b9f3e7b-de3b-4c90-bad6-a8760e3852eb)
 which would give you an output similar to the one below:
 
@@ -498,7 +498,7 @@ The field `version` represents the `version_id` in the following API example.
 
 ### Rollback Configuration
 After choosing a particular version, you can revert to that version by
-[rolling back](https://keboola.docs.apiary.io/#reference/components-and-configurations/rollback-configuration-version/rollback-version),
+[rolling back](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/components/-componentId-/configs/-configurationId-/versions/-versionId-/rollback),
 i.e., making a new version identical to the chosen one.  See an [example](https://documenter.getpostman.com/view/3086797/kbc-samples/77h845D#2050856a-66b3-4120-9552-d1278a96621e)
 of how to rollback the configuration `364479526` of the `keboola.ex-aws-s3` component to version `3`.
 
@@ -511,7 +511,7 @@ It will create a new version of the configuration and return the ID of the versi
 
 ### Creating Configuration Copy
 After choosing a particular version, you can create a new independent
-[configuration copy](https://keboola.docs.apiary.io/#reference/components-and-configurations/copy-configurations/create-configuration-copy)
+[configuration copy](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/components/-componentId-/configs/-configurationId-/versions/-versionId-/create)
 of it. See an [example](https://documenter.getpostman.com/view/3086797/kbc-samples/77h845D?version=latest#9b9f3e7b-de3b-4c90-bad6-a8760e3852eb)
 of how to create a new configuration called `test-copy` from version `3` of the `364479526` configuration
 for the `keboola.ex-aws-s3` component.

--- a/integrate/storage/api/import-export.md
+++ b/integrate/storage/api/import-export.md
@@ -13,10 +13,10 @@ Storage is a layer on top of a [database backend](https://help.keboola.com/stora
 
 To upload a table, take the following steps:
 
-- Request a [file upload](https://keboola.docs.apiary.io/#reference/files/upload-file/create-file-resource) from
+- Request a [file upload](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/files/prepare) from
 Keboola File Storage. You will be given a destination for the uploaded file on an S3 server.
 - Upload the file there. When the upload is finished, the data file will be available in the *File Uploads* section.
-- Initiate an [asynchronous table import](https://keboola.docs.apiary.io/#reference/tables/load-data-asynchronously/import-data-from-csv-file-asynchronously)
+- Initiate an [asynchronous table import](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/tables/-id-/import-async)
 from the uploaded file (use it as the `dataFileId` parameter) into the destination table.
 The import is asynchronous, so the request only creates a job and you need to poll for its results.
 The imported files must conform to the [RFC4180 Specification](https://tools.ietf.org/html/rfc4180).
@@ -27,12 +27,12 @@ The imported files must conform to the [RFC4180 Specification](https://tools.iet
 Exporting a table from Storage is analogous to its importing. First, data is [asynchronously
 exported](https://keboola.docs.apiary.io/#reference/tables/unload-data-asynchronously/asynchronous-export) from
 Table Storage into File Uploads. Then you can request to [download
-the file](https://keboola.docs.apiary.io/#reference/files/manage-files/file-detail), which will give you
+the file](https://api.keboola.com/?service=storage#get-/v2/storage/branch/-branchId-/files/-fileId-), which will give you
 access to an S3 server for the actual file download.
 
 ### Manually Uploading a File
 To upload a file to Keboola File Storage, follow the instructions outlined in the
-[API documentation](https://keboola.docs.apiary.io/#reference/files/upload-file/create-file-resource).
+[API documentation](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/files/prepare).
 First create a file resource; to create a new file called
 [`new-file.csv`](/integrate/storage/new-table.csv) with `52` bytes, call:
 
@@ -104,9 +104,9 @@ aws s3 cp new-table.csv s3://kbc-sapi-files/exp-15/1134/files/2016/06/22/1927266
 {% endhighlight %}
 
 After that, import the file into Table Storage, by calling either
-[Create Table API call](https://keboola.docs.apiary.io/#reference/tables/create-table-asynchronously/create-new-table-from-csv-file-asynchronously)
+[Create Table API call](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/buckets/-id-/tables-async)
 (for a new table) or
-[Load Data API call](https://keboola.docs.apiary.io/#reference/tables/load-data-asynchronously/import-data-from-csv-file-asynchronously)
+[Load Data API call](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/tables/-id-/import-async)
 (for an existing table).
 
 {% highlight bash %}
@@ -166,15 +166,15 @@ The above will return a response similar to this:
 {% endhighlight %}
 
 After that, import the file into Table Storage by calling either
-[Create Table API call](https://keboola.docs.apiary.io/#reference/tables/create-table-asynchronously/create-new-table-from-csv-file-asynchronously)
+[Create Table API call](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/buckets/-id-/tables-async)
 (for a new table) or
-[Load Data API call](https://keboola.docs.apiary.io/#reference/tables/load-data-asynchronously/import-data-from-csv-file-asynchronously)
+[Load Data API call](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/tables/-id-/import-async)
 (for an existing table).
 
 ### Working with Sliced Files
 Depending on the backend and table size, the data file may be sliced into chunks.
 Requirements for uploading sliced files are described in the respective part of the
-[API documentation](https://keboola.docs.apiary.io/#reference/files/upload-file/create-file-resource).
+[API documentation](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/files/prepare).
 
 When you attempt to download a sliced file, you will instead obtain its manifest
 listing the individual parts. Download the parts individually and join them
@@ -184,7 +184,7 @@ our [TableExporter class](https://github.com/keboola/storage-api-php-client/blob
 **Important:** When exporting a table through the *Table* --- *Export* UI, the file will
 be already merged and listed in the *File Uploads* section with the `storage-merged-export` tag.
 
-If you want to download a sliced file, [get credentials](https://keboola.docs.apiary.io/#reference/files/manage-files/file-detail)
+If you want to download a sliced file, [get credentials](https://api.keboola.com/?service=storage#get-/v2/storage/branch/-branchId-/files/-fileId-)
 to download the file from AWS S3. Assuming that the file ID is 192611596, for example, call
 
 {% highlight bash %}

--- a/integrate/storage/api/index.md
+++ b/integrate/storage/api/index.md
@@ -9,12 +9,12 @@ permalink: /integrate/storage/api/
 If you are new to Keboola, you should make yourself familiar with
 the [Storage component](https://help.keboola.com/storage/) before you start using it.
 For a general introduction to working with Keboola APIs, see the [API Introduction](/overview/api/).
-[Storage API](https://keboola.docs.apiary.io/) provides a number of functions. These are the most important ones:
+[Storage API](https://api.keboola.com/?service=storage) provides a number of functions. These are the most important ones:
 
-- [Component configurations](https://keboola.docs.apiary.io/#reference/components-and-configurations)
-- [Storage tables](https://keboola.docs.apiary.io/#reference/tables)
-- [File uploads](https://keboola.docs.apiary.io/#reference/files)
-- [Storage buckets](https://keboola.docs.apiary.io/#reference/buckets)
+- [Component configurations](https://api.keboola.com/?service=storage#tag--Component-Configurations)
+- [Storage tables](https://api.keboola.com/?service=storage#tag--Tables)
+- [File uploads](https://api.keboola.com/?service=storage#tag--Files)
+- [Storage buckets](https://api.keboola.com/?service=storage#tag--Buckets)
 
 Virtually, all API calls require a [Storage API token](https://help.keboola.com/storage/tokens/) to
 be passed as the `X-StorageApi-Token` header.

--- a/integrate/storage/api/tde-exporter.md
+++ b/integrate/storage/api/tde-exporter.md
@@ -22,7 +22,7 @@ custom configurations supplied directly in the `run` request.
 
 ### Stored Configuration
 To run the TDE exporter with a stored configuration, first
-[create the configuration](https://keboola.docs.apiary.io/#reference/components-and-configurations/component-configurations/create-configuration).
+[create the configuration](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/components/-componentId-/configs).
 See [below](#custom-configuration) for the required configuration contents.
 This call will give you the ID of the newly created configuration (for instance, `new-configuration-id`).
 Then [create a job](/integrate/jobs/) with the specified configuration:

--- a/integrate/storage/docker-cli-client.md
+++ b/integrate/storage/docker-cli-client.md
@@ -8,7 +8,7 @@ redirect_from: /integrate/storage/php-cli-client/
 {:toc}
 
 The Storage API Docker command line interface (CLI) client is a portable command line client which provides
-a simple implementation of [Storage API](https://keboola.docs.apiary.io/#).
+a simple implementation of [Storage API](https://api.keboola.com/?service=storage).
 It runs on any platform which has Docker installed.
 
 Currently, the client implements

--- a/integrate/storage/index.md
+++ b/integrate/storage/index.md
@@ -13,7 +13,7 @@ As the central Keboola component, Storage
 - Logs all data manipulations as **events**;
 - Maintains the index of all other Keboola **components** and stores their **configurations**.
 
-All this (and a few other things) is available through [Storage API (SAPI)](https://keboola.docs.apiary.io/#).
+All this (and a few other things) is available through [Storage API (SAPI)](https://api.keboola.com/?service=storage).
 To authorize access to a specific project, most calls to Storage API require
 a [Storage API Token](https://help.keboola.com/storage/tokens/) along with your request.
 It is required regardless of whether you use the bare API or any of the clients.

--- a/integrate/storage/php-client.md
+++ b/integrate/storage/php-client.md
@@ -7,7 +7,7 @@ permalink: /integrate/storage/php-client/
 {:toc}
 
 The Storage API PHP client library is a portable command line client providing
-the most complete [Storage API](https://keboola.docs.apiary.io/#) implementation.
+the most complete [Storage API](https://api.keboola.com/?service=storage) implementation.
 It runs on any platform which has PHP installed.
 Currently this client implements almost all Storage API functions including, of course, exporting and importing tables.
 
@@ -127,7 +127,7 @@ $csvFile = new CsvFile('./new-table.csv');
 $client->writeTableAsync('in.c-main.new-table', $csvFile, ['incremental' => true]);
 {% endhighlight %}
 
-All available upload options are listed in the [API documentation](https://keboola.docs.apiary.io/#reference/tables/load-data-asynchronously/import-data-from-csv-file-asynchronously).
+All available upload options are listed in the [API documentation](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/tables/-id-/import-async).
 
 ### Example --- Export Data
 To export data from a Storage table to a CSV file, use the

--- a/integrate/storage/python-client.md
+++ b/integrate/storage/python-client.md
@@ -6,7 +6,7 @@ permalink: /integrate/storage/python-client/
 * TOC
 {:toc}
 
-The Python client library is a [Storage API client](https://keboola.docs.apiary.io/#) which you can use in your Python code.
+The Python client library is a [Storage API client](https://api.keboola.com/?service=storage) which you can use in your Python code.
 The current implementation supports all basic data manipulations:
 
 - Importing data

--- a/integrate/storage/r-client.md
+++ b/integrate/storage/r-client.md
@@ -6,7 +6,7 @@ permalink: /integrate/storage/r-client/
 * TOC
 {:toc}
 
-The R client library is a [Storage API client](https://keboola.docs.apiary.io/) which you can use in your R code.
+The R client library is a [Storage API client](https://api.keboola.com/?service=storage) which you can use in your R code.
 The current implementation supports all basic data manipulations:
 
 - Importing data

--- a/integrate/variables/index.md
+++ b/integrate/variables/index.md
@@ -19,7 +19,7 @@ See [Tutorial](/integrate/variables/tutorial) for step-by-step example.
 ## Introduction
 When using variables, the configuration is treated as a [Moustache template](https://mustache.github.io/mustache.5.html). 
 You can enter variables anywhere in the JSON of the configuration body. The configuration body is the contents of 
-the `configuration` node when you [retrieve a configuration](https://keboola.docs.apiary.io/#reference/components-and-configurations/manage-configurations/configuration-detail).
+the `configuration` node when you [retrieve a configuration](https://api.keboola.com/?service=storage#get-/v2/storage/branch/-branchId-/components/-componentId-/configs/-configurationId-).
 This means that you can't use variables in a name or in a configuration description. 
 
 Variables are entered using the [Moustache syntax](https://mustache.github.io/mustache.5.html), 
@@ -39,7 +39,7 @@ or `keboola.snowflake-transformation`, etc.), and an orchestrator (see [below](#
 A *variable configuration* is a standard configuration tied to a special dedicated `keboola.variables` component. 
 The variable configuration defines names of variables to be replaced in the main configuration. You can create 
 the configuration using the 
-[Create Configuration API call](https://keboola.docs.apiary.io/#reference/components-and-configurations/component-configurations/create-configuration). 
+[Create Configuration API call](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/components/-componentId-/configs). 
 This is an example of the contents of such a configuration:
 
 {% highlight json %}
@@ -143,7 +143,7 @@ will be interpreted as (assuming the variables `alias=batman` and `size=big` are
 In this example, we will configure a Python transformation using variables.
 
 ### Step 1 -- Create Variable Configuration
-Use the [Create Configuration API call](https://keboola.docs.apiary.io/#reference/components-and-configurations/component-configurations/create-configuration) 
+Use the [Create Configuration API call](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/components/-componentId-/configs) 
 for the `keboola.variables` component with the following content:
 
 {% highlight json %}
@@ -166,7 +166,7 @@ See an [example](https://documenter.getpostman.com/view/3086797/77h845D?version=
 ### Step 2 -- Create Default Values for Variables
 Note that this step is optional -- you can use variables without default values.
 In the previous step, you obtained an ID of the variable configuration. Use the 
-[Create Configuration Row API call](https://keboola.docs.apiary.io/#reference/components-and--configurations/create-or-list-configuration-rows/create-configuration-row).
+[Create Configuration Row API call](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/components/-componentId-/configs/-configurationId-/rows).
 Use the ID of the variable configuration and `keboola.variables` as a component. Use the following body:
 
 {% highlight json %}
@@ -472,7 +472,7 @@ to [running a job](/integrate/variables/#step-4--run-job).
 
 ### Step 5 -- Create Orchestration
 You have to use the 
-[Create Configuration API call](https://keboola.docs.apiary.io/#reference/components-and-configurations/component-configurations/create-configuration)
+[Create Configuration API call](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/components/-componentId-/configs)
 to create a configuration of the `keboola.orchestrator` component. 
 You can use the following data in the configuration:
 
@@ -600,7 +600,7 @@ piece of a shared code, you first have to create a configuration. Notice that th
 certain components so you might want to check the existing configurations of `keboola.shared-code` component before
 crating a new configuration.
 
-To create a configuration, use the [create configuration API call](https://keboola.docs.apiary.io/#reference/components-and-configurations/component-configurations/create-configuration). The configuration content is ignored, i.e all you need to provide is name:
+To create a configuration, use the [create configuration API call](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/components/-componentId-/configs). The configuration content is ignored, i.e all you need to provide is name:
 
 {% highlight bash %}
 curl --location --request POST 'https://connection.keboola.com/v2/storage/components/keboola.shared-code/configs' \

--- a/integrate/variables/tutorial.md
+++ b/integrate/variables/tutorial.md
@@ -61,7 +61,7 @@ export VARIABLE_CONFIG='
 '
 ```
 
-Use [Create Configuration API call](https://keboola.docs.apiary.io/#reference/components-and-configurations/component-configurations/create-configuration) to store *variable configuration*.
+Use [Create Configuration API call](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/components/-componentId-/configs) to store *variable configuration*.
 ```shell
 curl --include \
      --request POST \
@@ -123,7 +123,7 @@ export EXTRACTOR_CONFIG='
 {% endraw %}
 ```
 
-Use [Create Configuration API call](https://keboola.docs.apiary.io/#reference/components-and-configurations/component-configurations/create-configuration) to store extractor configuration.
+Use [Create Configuration API call](https://api.keboola.com/?service=storage#post-/v2/storage/branch/-branchId-/components/-componentId-/configs) to store extractor configuration.
 ```shell
 curl --include \
      --request POST \

--- a/overview/index.md
+++ b/overview/index.md
@@ -19,7 +19,7 @@ The following chart shows how Keboola is structured. All Keboola parts are brief
 
 ## Working with Keboola
 Everything you can do in the Keboola UI can be done programatically using the API of the corresponding component.
-All of our components have API documentation on [Apiary](https://keboola.docs.apiary.io/#) and
+All of our components have API documentation on [api.keboola.com](https://api.keboola.com/) and
 most of them have a public [Github repository](https://github.com/keboola/).
 Our Docker components are built on [AWS ECR](https://aws.amazon.com/ecr/).
 
@@ -48,7 +48,7 @@ For more details, see
 ### Components Configuration
 All components store their configuration in [Storage](/integrate/storage/). Management of the
 configurations is done through
-[Storage Components Configurations API](https://keboola.docs.apiary.io/#reference/components-and-configurations).
+[Storage Components Configurations API](https://api.keboola.com/?service=storage#tag--Component-Configurations).
 Stored configurations can be referenced in `/run` API calls.
 
 Configuration can be defined with a JSON schema stored within the Component detail.


### PR DESCRIPTION
Linear issue: https://linear.app/keboola/issue/AJDA-2897/odstranit-zbyvajici-odkazy-na-apiary

Stacked on top of #388 (base is `odin/AJDA-2897-3`, not `main`).

Repoints the Storage API documentation links from the legacy `keboola.docs.apiary.io` to the `api.keboola.com` portal (`?service=storage`). Anchors were derived from the Storage OpenAPI spec: `#tag--<Section>` for sections and `#<method>-/v2/storage/...` (with `-param-` placeholders) for individual endpoints.

Changes:

- **92 links converted across 33 files.**
- `list-components` / `get-components` / `api-index/component-list` → `#get-/v2/storage`.
- Dev-branch section links → `#get-/v2/storage/dev-branches/-id-`; `list-branches` → `#get-/v2/storage/dev-branches`.
- **Metadata:** unlinked the bare `[Metadata]` references that were already followed by specific Table/Column Metadata endpoint links; added those specific links to the standalone in-tables manifest case.
- Bare "Storage API" landing links → `?service=storage`; reworded the "API documentation on Apiary" line in `overview/index.md`.

### Intentionally left on Apiary (no equivalent in the new Storage API)

The new Storage API has **no table export-to-file endpoint** (only workspace `table-export`/`unload`), so these 4 links were left pointing at `keboola.docs.apiary.io` on purpose:

- `extend/common-interface/config-file.md:278` — "Storage API export table options"
- `extend/job-queue/index.md:85` — "unload data"
- `integrate/jobs/index.md:301` — "exports"
- `integrate/storage/api/import-export.md:28` — "asynchronously exported"

If/when the export endpoint surfaces in the spec, these can be repointed in a follow-up.

---

Note: stacked on #388 → #387 → #386 → #385. Merge in that order; GitHub retargets the base automatically as each lands.